### PR TITLE
Updated link to new Chart.Js repository.

### DIFF
--- a/src/BlazorBoilerplate.Client/Pages/Dashboard.razor
+++ b/src/BlazorBoilerplate.Client/Pages/Dashboard.razor
@@ -5,7 +5,7 @@
 
 <p>
     Expecting to see a bunch of flashy charts then you download the repo and delete them all because you don't need them? <br />
-    Check out <a href="https://github.com/mariusmuntean/ChartJs.Blazor" target="_blank">https://github.com/mariusmuntean/ChartJs.Blazor</a> or <a href="https://www.iheartblazor.com/" target="_blank">here</a> and you will find a great resource for animated charts for a dashboard.<br />
+    Check out <a href="https://github.com/Joelius300/ChartJSBlazor" target="_blank">https://github.com/Joelius300/ChartJSBlazor</a> and you will find a great resource for animated charts for a dashboard.<br />
 </p>
 <hr />
 <h2>Counter</h2>


### PR DESCRIPTION
The old Chart.Js repository for Blazor from https://github.com/mariusmuntean/ChartJs.Blazor is not maintained any longer. @Joelius300 has created a new fork here: https://github.com/Joelius300/ChartJSBlazor.