### PR TITLE
refactor sign in

### DIFF
--- a/src/BlazorBoilerplate.Server/Controllers/AccountController.cs
+++ b/src/BlazorBoilerplate.Server/Controllers/AccountController.cs
@@ -67,13 +67,13 @@ namespace BlazorBoilerplate.Server.Controllers
                 if (result.IsLockedOut)
                 {
                     _logger.LogInformation("User Locked out: {0}", parameters.UserName);
-                    return new ApiResponse(400, "Login Failed!");
+                    return new ApiResponse(401, "Login Failed!");
                 }
 
                 if (result.IsNotAllowed)
                 {
                     _logger.LogInformation("User not allowed to log in: {0}", parameters.UserName);
-                    return new ApiResponse(400, "Login Failed!");
+                    return new ApiResponse(401, "Login Failed!");
                 }
 
                 if (result.Succeeded)
@@ -88,7 +88,7 @@ namespace BlazorBoilerplate.Server.Controllers
             }
 
             _logger.LogInformation("Invalid Password for user {0}}", parameters.UserName);
-            return new ApiResponse(400, "Login Failed");
+            return new ApiResponse(401, "Login Failed");
         }
 
         [AllowAnonymous]

--- a/src/BlazorBoilerplate.Server/Controllers/AccountController.cs
+++ b/src/BlazorBoilerplate.Server/Controllers/AccountController.cs
@@ -64,12 +64,14 @@ namespace BlazorBoilerplate.Server.Controllers
             {
                 var result = await _signInManager.PasswordSignInAsync(parameters.UserName, parameters.Password,  parameters.RememberMe, true);
 
+                // If lock out activated and the max. amounts of attempts is reached.
                 if (result.IsLockedOut)
                 {
                     _logger.LogInformation("User Locked out: {0}", parameters.UserName);
                     return new ApiResponse(401, "User is locked out!");
                 }
 
+                // If your email is not confirmed but you require it in the settings for login.
                 if (result.IsNotAllowed)
                 {
                     _logger.LogInformation("User not allowed to log in: {0}", parameters.UserName);

--- a/src/BlazorBoilerplate.Server/Controllers/AccountController.cs
+++ b/src/BlazorBoilerplate.Server/Controllers/AccountController.cs
@@ -25,7 +25,7 @@ namespace BlazorBoilerplate.Server.Controllers
     public class AccountController : ControllerBase
     {
         private static readonly UserInfoDto LoggedOutUser = new UserInfoDto { IsAuthenticated = false, Roles = new List<string>() };
-               
+
         private readonly ILogger<AccountController> _logger;
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly SignInManager<ApplicationUser> _signInManager;
@@ -60,42 +60,34 @@ namespace BlazorBoilerplate.Server.Controllers
                 return new ApiResponse(400, "User Model is Invalid");
             }
 
-            var user = await _userManager.FindByEmailAsync(parameters.UserName)
-                       ?? await _userManager.FindByNameAsync(parameters.UserName);
-
-            if (!user.EmailConfirmed && Convert.ToBoolean(_configuration["BlazorBoilerplate:RequireConfirmedEmail"] ?? "false"))
-            {
-                return new ApiResponse(401, "User has not confirmed their email.");
-            }
-
-            if (user == null)
-            {
-                _logger.LogInformation("User does not exist: {0}", parameters.UserName);
-                return new ApiResponse(404, "User does not exist");
-            }
-
-            var singInResult = await _signInManager.CheckPasswordSignInAsync(user, parameters.Password, false);
-
-            if (!singInResult.Succeeded)
-            {
-                _logger.LogInformation("Invalid password: {0}, {1}", parameters.UserName, parameters.Password);
-                return new ApiResponse(400, "Invalid password");
-            }
-
-            // add custom claims here, before signin if needed
-            //var claims = await _userManager.GetClaimsAsync(user);
-            //await _userManager.RemoveClaimsAsync(user, claims);
-            user.SecurityStamp = Guid.NewGuid().ToString();
             try
             {
-                await _signInManager.SignInAsync(user, parameters.RememberMe);
-                _logger.LogInformation("Logged In: {0}, {1}", parameters.UserName, parameters.Password);
-                return new ApiResponse(200, "Login Successful");
+                var result = await _signInManager.PasswordSignInAsync(parameters.UserName, parameters.Password,  parameters.RememberMe, true);
+
+                if (result.IsLockedOut)
+                {
+                    _logger.LogInformation("User Locked out: {0}", parameters.UserName);
+                    return new ApiResponse(400, "Login Failed!");
+                }
+
+                if (result.IsNotAllowed)
+                {
+                    _logger.LogInformation("User not allowed to log in: {0}", parameters.UserName);
+                    return new ApiResponse(400, "Login Failed!");
+                }
+
+                if (result.Succeeded)
+                {
+                    _logger.LogInformation("Logged In: {0}", parameters.UserName);
+                    return new ApiResponse(200, "Login Successful");
+                }
             }
             catch (Exception ex)
             {
                 _logger.LogInformation("Login Failed: " + ex.Message);
             }
+
+            _logger.LogInformation("Invalid Password for user {0}}", parameters.UserName);
             return new ApiResponse(400, "Login Failed");
         }
 
@@ -361,7 +353,7 @@ namespace BlazorBoilerplate.Server.Controllers
                     _logger.LogWarning("Could not build UserInfoDto: " + ex.Message);
                 }
             }
-            else 
+            else
             {
                 return new UserInfoDto();
             }
@@ -400,10 +392,10 @@ namespace BlazorBoilerplate.Server.Controllers
 
             return new ApiResponse(200, "User Updated Successfully");
         }
-        
+
 
         ///----------Admin User Management Interface Methods
-        
+
         [Authorize(Policy = Policies.IsAdmin)]
         // POST: api/Account/Create
         [HttpPost("Create")]
@@ -525,10 +517,10 @@ namespace BlazorBoilerplate.Server.Controllers
             }
             catch
             {
-                return new ApiResponse(400, "User Deletion Failed");                
-            }            
+                return new ApiResponse(400, "User Deletion Failed");
+            }
         }
-        
+
         [HttpGet("GetUser")]
         [Authorize]
         public ApiResponse GetUser()
@@ -603,13 +595,13 @@ namespace BlazorBoilerplate.Server.Controllers
 
             // retrieve full user object for updating
             var appUser = await _userManager.FindByIdAsync(userInfo.UserId.ToString()).ConfigureAwait(true);
-            
+
             //update values
             appUser.UserName = userInfo.UserName;
             appUser.FirstName = userInfo.FirstName;
             appUser.LastName = userInfo.LastName;
             appUser.Email = userInfo.Email;
-                                          
+
             try
             {
                 var result = await _userManager.UpdateAsync(appUser).ConfigureAwait(true);
@@ -720,7 +712,7 @@ namespace BlazorBoilerplate.Server.Controllers
                         {
                             resultErrorsString += identityError.Description + ", ";
                         }
-                        resultErrorsString.TrimEnd(',');                        
+                        resultErrorsString.TrimEnd(',');
                         return new ApiResponse(400, resultErrorsString);
                     }
                     else
@@ -733,7 +725,7 @@ namespace BlazorBoilerplate.Server.Controllers
             {
                 _logger.LogInformation(user.UserName + "'s password reset failed; Requested from Admin interface by:" + User.Identity.Name);
                 return new ApiResponse(400, ex.Message);
-            }            
+            }
         }
     }
 }

--- a/src/BlazorBoilerplate.Server/Controllers/AccountController.cs
+++ b/src/BlazorBoilerplate.Server/Controllers/AccountController.cs
@@ -52,7 +52,7 @@ namespace BlazorBoilerplate.Server.Controllers
 
         [AllowAnonymous]
         [ProducesResponseType(204)]
-        [ProducesResponseType(400)]
+        [ProducesResponseType(401)]
         public async Task<ApiResponse> Login(LoginDto parameters)
         {
             if (!ModelState.IsValid)

--- a/src/BlazorBoilerplate.Server/Controllers/AccountController.cs
+++ b/src/BlazorBoilerplate.Server/Controllers/AccountController.cs
@@ -67,13 +67,13 @@ namespace BlazorBoilerplate.Server.Controllers
                 if (result.IsLockedOut)
                 {
                     _logger.LogInformation("User Locked out: {0}", parameters.UserName);
-                    return new ApiResponse(401, "Login Failed!");
+                    return new ApiResponse(401, "User is locked out!");
                 }
 
                 if (result.IsNotAllowed)
                 {
                     _logger.LogInformation("User not allowed to log in: {0}", parameters.UserName);
-                    return new ApiResponse(401, "Login Failed!");
+                    return new ApiResponse(401, "Login not allowed!");
                 }
 
                 if (result.Succeeded)


### PR DESCRIPTION
I refactored the sign in a bit so that it only uses the sign in manager and the Password Sign In. For the difference between the two see here: 
https://stackoverflow.com/questions/53854051/usermanager-checkpasswordasync-vs-signinmanager-passwordsigninasync

Also I changed that the values returned to the best practice to not  provide security relevant information (for example if a user with a particular username exists or not). And it returns the Http Status Code 401 instead of 400 or 404 in case of an invalid login attempt, since the request was valid. Therefore I think this one is a better match.

EDIT: I adjusted the return message for lockout and not allowed (that is for example when your email is not confirmed but you require it). Since you only get these when the provided login information where correct I think these don't go under "provide more information". 

I also adjusted the logging so that not the clear text password is logged.