### PR TITLE
Fixes #71 - updated dockerfile, docker-compose.yml

### DIFF
--- a/src/BlazorBoilerplate.Server/appsettings.Development.json
+++ b/src/BlazorBoilerplate.Server/appsettings.Development.json
@@ -1,62 +1,15 @@
 {
-  "ConnectionStrings": {
-    "DefaultConnection": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=blazor_boilerplate;Trusted_Connection=True;MultipleActiveResultSets=true",
-    "SqlLiteConnectionFileName": "data.db"
-  },
-
 
   "BlazorBoilerplate": {
     "ApplicationUrl": "http://localhost:53414",
-    "RequireConfirmedEmail": false,
-    "APILogging": {
-      "Enabled": true,
-      "IgnorePaths": [ "/api/userprofile" ]
-    },
     "UseSqlServer": true,
-    "UseSqlLite": false
+    "IS4ApplicationUrl": "http://localhost:53414"
   },
 
-  "EmailConfiguration": {
-    "FromName": "Blazor Boilerplate",
-    "FromAddress": "email@domain.com",
-    "ReplyToAddress": "email@domain.com",
-    "SmtpServer": "smtp.gmail.com",
-    "SmtpPort": 587,
-    "SmtpUseSSL": true,
-    "SmtpUsername": "email@domain.com",
-    "SmtpPassword": "PASSWORD",
-    "PopServer": "pop.gmail.com",
-    "PopPort": 995,
-    "PopUseSSL": true,
-    "PopUsername": "email@domain.com",
-    "PopPassword": "PASSWORD",
-    "ImapServer": "imap.gmail.com",
-    "ImapPort": 993,
-    "ImapUseSSL": true,
-    "ImapUsername": "email@domain.com",
-    "ImapPassword": "PASSWORD"
-  },
 
   "Serilog": {
-    "Using": [ "Serilog.Sinks.File" ],
-    "Enrich": [ "FromLogContext", "WithMachineName", "WithProcessId", "WithThreadId" ],
     "MinimumLevel": {
-      "Default": "Debug",
-      "Override": {
-        "Microsoft": "Warning",
-        "System": "Warning"
-      }
-    },
-    "WriteTo": [
-      {
-        "Name": "File",
-        "Args": {
-          "path": "Logs\\log-.log",
-          "rollingInterval": "Day",
-          "retainedFileCountLimit": 5
-        }
-      }
-    ]
-  },
-  "AllowedHosts": "*"
+      "Default": "Debug"
+    }
+  }
 }

--- a/src/BlazorBoilerplate.Server/appsettings.json
+++ b/src/BlazorBoilerplate.Server/appsettings.json
@@ -12,7 +12,6 @@
       "IgnorePaths": [ "/api/userprofile" ]
     },
     "UseSqlServer": true,
-    "UseSqlLite": false,
     "IS4ApplicationUrl": "https://blazorboilerplate.com",
     "UseLocalCertStore": "true",
     "CertificateThumbprint": "PutYourSSLThumbPrintHere"

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.0-buster-slim AS base
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.0-buster AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
 WORKDIR /src
 COPY ["/BlazorBoilerplate.Server/BlazorBoilerplate.Server.csproj", "BlazorBoilerplate.Server/"]
 COPY ["/BlazorBoilerplate.Shared/BlazorBoilerplate.Shared.csproj", "BlazorBoilerplate.Shared/"]
@@ -10,7 +10,7 @@ COPY ["/BlazorBoilerplate.Client/BlazorBoilerplate.Client.csproj", "BlazorBoiler
 RUN dotnet restore "BlazorBoilerplate.Server/BlazorBoilerplate.Server.csproj"
 COPY . .
 WORKDIR "/src/BlazorBoilerplate.Server"
-RUN dotnet build "BlazorBoilerplate.Server.csproj" -c Release -o /app/build
+RUN dotnet build "BlazorBoilerplate.Server.csproj" -c Release -o /app/build --no-restore
 
 FROM build AS publish
 RUN dotnet publish "BlazorBoilerplate.Server.csproj" -c Release -o /app/publish

--- a/src/docker-compose.dcproj
+++ b/src/docker-compose.dcproj
@@ -9,9 +9,6 @@
     <DockerServiceName>blazorboilerplate.server</DockerServiceName>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="docker-compose.override.yml">
-      <DependentUpon>docker-compose.yml</DependentUpon>
-    </None>
     <None Include="docker-compose.yml" />
     <None Include=".dockerignore" />
   </ItemGroup>

--- a/src/docker-compose.override.yml
+++ b/src/docker-compose.override.yml
@@ -1,8 +1,0 @@
-version: '3.4'
-
-services:
-  blazorboilerplate:
-    environment:
-      - ASPNETCORE_ENVIRONMENT=Development
-    ports:
-      - "80"

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - BlazorBoilerplate__IS4ApplicationUrl=blazorboilerplate
     networks:
       - bb
+    restart: on-failure
 
   sqlserver:
     image: mcr.microsoft.com/mssql/server

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -1,26 +1,41 @@
-version: '3.4'
+version: '3.5'
 
 services:
-    blazorboilerplate:
-        build:
-          context: ./
-        ports:
-            - "8000:80"
-        depends_on:
-            - db
-        environment:
-            DOCKER_COMPOSE_SQL: "db"
-            MSSQL_USER: "sa"
-            SA_PASSWORD: "Your_password123"
-            ASPNETCORE_ENVIRONMENT: "Development"
+  blazorboilerplate:
+    build:
+      context: ./
+      dockerfile: ./Dockerfile
+    ports:
+      - 53415:80
+    depends_on:
+      - sqlserver
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development #Consider changing this in Production
+      - Serilog__MinimumLevel__Default=Debug #Consider changing this in Production
+      - ConnectionStrings__DefaultConnection=Server=sqlserver;Database=blazor_boilerplate;Trusted_Connection=True;MultipleActiveResultSets=true;User=sa;Password=yourVeryStrong(!)Password;Integrated Security=false
+      - BlazorBoilerplate__UseSqlServer=true
+      - BlazorBoilerplate__ApplicationUrl=blazorboilerplate
+      - BlazorBoilerplate__IS4ApplicationUrl=blazorboilerplate
+    networks:
+      - bb
 
-    db:
-        image: "mcr.microsoft.com/mssql/server"
-        volumes:
-            - db_data:/var/opt/mssql
-        environment:
-            SA_PASSWORD: "Your_password123"
-            ACCEPT_EULA: "Y"
+  sqlserver:
+    image: mcr.microsoft.com/mssql/server
+    volumes:
+      - dbdata:/var/opt/mssql
+    environment:
+      - SA_PASSWORD=yourVeryStrong(!)Password
+      - ACCEPT_EULA=Y
+    ports:
+      - 1533:1433 #expose port, so can connect to it using host: 'localhost,1533' | user: sa, password: yourVeryStrong(!)Password
+    networks:
+      - bb  
 
 volumes:
-    db_data:
+  dbdata:
+
+networks:
+  bb:
+    name: bb_network
+    ipam:
+      driver: default


### PR DESCRIPTION
Fixes #71 - updated dockerfile, docker-compose.yml to override connetion strings and cleaned up Startup.cs removing duplicate code related to DB setup

------------------------------------------------------------------------------
App runs standalone as always, entrypoint is the Server project.
In docker environment, open CMD / PS and navigate to <repo_root>/Src directory and run
**docker-compose build
docker-compose up -d**

_SqlServer container needs some time to start. Thats why the blazor container is setup with restart policy to try to reconnect until the DB is responding_

**docker-compose down - closes everything down**

In docker-compose.yml, if you want to connect to the SqlServer running **locally** (not the docker sqlserver instance), replace ConnectionStrings__DefaultConnection value

Server=sqlserver;Database=blazor_boilerplate;Trusted_Connection=True;MultipleActiveResultSets=true;User=sa;Password=yourVeryStrong(!)Password;Integrated Security=false

with the valid connection string to your local instance (using machine **host IP** (local) (keep in mind that WindowsAuth won't work, it has to be SqlServerAuth) i.e.:
Server=192.168.1.105,1433;Database=blazor_boilerplate;Trusted_Connection=True;MultipleActiveResultSets=true;User=localSqlUser;Password=MyAwesomePassword;Integrated Security=false