### PR TITLE
Add SameSite.None to the cookie policy due to Chrome's new cookie policy

### DIFF
--- a/src/BlazorBoilerplate.Server/Startup.cs
+++ b/src/BlazorBoilerplate.Server/Startup.cs
@@ -338,10 +338,11 @@ namespace BlazorBoilerplate.Server
               //    app.UseHsts(); //HSTS Middleware (UseHsts) to send HTTP Strict Transport Security Protocol (HSTS) headers to clients.
             }
 
+            app.UseHttpsRedirection();
             //app.UseStaticFiles();
+            app.UseCookiePolicy();
             app.UseClientSideBlazorFiles<Client.Startup>();
 
-            app.UseHttpsRedirection();
             app.UseRouting();
             //app.UseAuthentication();
             app.UseIdentityServer();

--- a/src/BlazorBoilerplate.Server/Startup.cs
+++ b/src/BlazorBoilerplate.Server/Startup.cs
@@ -48,6 +48,23 @@ namespace BlazorBoilerplate.Server
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                options.MinimumSameSitePolicy = SameSiteMode.None;
+            });
+
+            services.ConfigureExternalCookie(options =>
+            {
+                // macOS login fix
+                options.Cookie.SameSite = SameSiteMode.None;
+            });
+
+            services.ConfigureApplicationCookie(options =>
+            {
+                // macOS login fix
+                options.Cookie.SameSite = SameSiteMode.None;
+            });
+
             services.Configure<ApiBehaviorOptions>(options => { options.SuppressModelStateInvalidFilter = true; });
 
             var migrationsAssembly = typeof(Startup).GetTypeInfo().Assembly.GetName().Name;


### PR DESCRIPTION
This PR will set the cookie policy on the cookies.

If you receive:

`A cookie associated with a cross-site resource at .... was set without the `SameSite` attribute. A future release of Chrome will only deliver cookies with cross-site requests if they are set with `SameSite=None` and `Secure`. You can review cookies in developer tools under Application>Storage>Cookies and see more details at https://www.chromestatus.com/feature/5088147346030592 and https://www.chromestatus.com/feature/5633521622188032.`

This means the cookies weren't' set with any Cookie.SameSite attribute. Chrome will soon not allow any cookies that weren't explicitly set like that.

I'm not quite sure if this is something that is fixed in the default cookie policies from Identity, but this fix will be enough to keep working after the new policy will be introduced.

If anyone has a better solution, please inform me.