### PR TITLE
Fix for GetUserInfo 401 error

### DIFF
--- a/src/BlazorBoilerplate.Client/Pages/Account/Login.razor
+++ b/src/BlazorBoilerplate.Client/Pages/Account/Login.razor
@@ -69,9 +69,9 @@
 
     protected override async Task OnParametersSetAsync()
     {
-        var user = (await authenticationStateTask).User;
+        var user = await authStateProvider.GetUserInfo();
 
-        if (user.Identity.IsAuthenticated)
+        if (user.IsAuthenticated)
         {
             navigationManager.NavigateTo(navigationManager.BaseUri + navigateTo);
         }

--- a/src/BlazorBoilerplate.Client/Pages/Account/Login.razor
+++ b/src/BlazorBoilerplate.Client/Pages/Account/Login.razor
@@ -69,9 +69,9 @@
 
     protected override async Task OnParametersSetAsync()
     {
-        var user = await authStateProvider.GetUserInfo();
+        var user = (await authenticationStateTask).User;
 
-        if (user.IsAuthenticated)
+        if (user.Identity.IsAuthenticated)
         {
             navigationManager.NavigateTo(navigationManager.BaseUri + navigateTo);
         }

--- a/src/BlazorBoilerplate.Client/Pages/Account/Profile.razor
+++ b/src/BlazorBoilerplate.Client/Pages/Account/Profile.razor
@@ -8,41 +8,46 @@
 
 <h1>User Profile</h1>
 <p>User profile management. Work in progress.</p>
-<EditForm Model="@userInfo" OnValidSubmit="@UpdateUser">
-    <DataAnnotationsValidator />
-    <ValidationSummary />
-    <fieldset>
-        <div class="form-group">
-            <MatTextField @bind-Value="@userInfo.UserName" Label="User Name" Icon="person" IconTrailing="true" FullWidth="true" Required="true" ReadOnly="true"></MatTextField>
-        </div>
-        <div class="form-group">
-            <MatTextField @bind-Value="@userInfo.Email" Label="Email" Icon="mail_outline" IconTrailing="true" FullWidth="true" Required="true"></MatTextField>
-        </div>
-        <div class="form-group">
-            <MatTextField @bind-Value="@userInfo.FirstName" Label="First Name" FullWidth="true"></MatTextField>
-        </div>
-        <div class="form-group">
-            <MatTextField @bind-Value="@userInfo.LastName" Label="Last Name" FullWidth="true"></MatTextField>
-        </div>
+@if (userInfo == null)
+{
+    <LoadingBackground ShowLogoBox="true"></LoadingBackground>
+}
+else
+{
+    <EditForm Model="@userInfo" OnValidSubmit="@UpdateUser">
+        <DataAnnotationsValidator />
+        <ValidationSummary />
+        <fieldset>
+            <div class="form-group">
+                <MatTextField @bind-Value="@userInfo.UserName" Label="User Name" Icon="person" IconTrailing="true" FullWidth="true" Required="true" ReadOnly="true"></MatTextField>
+            </div>
+            <div class="form-group">
+                <MatTextField @bind-Value="@userInfo.Email" Label="Email" Icon="mail_outline" IconTrailing="true" FullWidth="true" Required="true"></MatTextField>
+            </div>
+            <div class="form-group">
+                <MatTextField @bind-Value="@userInfo.FirstName" Label="First Name" FullWidth="true"></MatTextField>
+            </div>
+            <div class="form-group">
+                <MatTextField @bind-Value="@userInfo.LastName" Label="Last Name" FullWidth="true"></MatTextField>
+            </div>
 
-        <div class="form-group">
-            <strong>Roles</strong><br />
-            <MatChipSet>
-                @foreach (var role in userInfo.Roles)
-                {
-                    <MatChip Label="@role"></MatChip>
-                }
-            </MatChipSet>
-        </div>
-        <div class="form-group d-flex justify-content-end">
-            <MatButton Type="submit" Raised="true">Update Profile</MatButton>
-        </div>
-    </fieldset>
-</EditForm>
-
-
+            <div class="form-group">
+                <strong>Roles</strong><br />
+                <MatChipSet>
+                    @foreach (var role in userInfo.Roles)
+                    {
+                        <MatChip Label="@role"></MatChip>
+                    }
+                </MatChipSet>
+            </div>
+            <div class="form-group d-flex justify-content-end">
+                <MatButton Type="submit" Raised="true">Update Profile</MatButton>
+            </div>
+        </fieldset>
+    </EditForm>
+}
 @code {
-    UserInfoDto userInfo { get; set; } = new UserInfoDto();
+    UserInfoDto userInfo;
 
     [Parameter]
     public string UserId { get; set; }

--- a/src/BlazorBoilerplate.Client/Services/Contracts/IAuthorizeApi.cs
+++ b/src/BlazorBoilerplate.Client/Services/Contracts/IAuthorizeApi.cs
@@ -14,5 +14,6 @@ namespace BlazorBoilerplate.Client.Services.Contracts
         Task<ApiResponseDto> ConfirmEmail(ConfirmEmailDto confirmEmailParameters);
         Task<UserInfoDto> GetUserInfo();
         Task<ApiResponseDto> UpdateUser(UserInfoDto userInfo);
+        Task<UserInfoDto> GetUser();
     }
 }

--- a/src/BlazorBoilerplate.Client/Services/Implementations/AuthorizeApi.cs
+++ b/src/BlazorBoilerplate.Client/Services/Implementations/AuthorizeApi.cs
@@ -57,13 +57,20 @@ namespace BlazorBoilerplate.Client.Services.Implementations
         {
             UserInfoDto userInfo = new UserInfoDto { IsAuthenticated = false, Roles = new List<string>() };
             ApiResponseDto apiResponse = await _httpClient.GetJsonAsync<ApiResponseDto>("api/Account/UserInfo");
-            
+
             if (apiResponse.StatusCode == 200)
             {
                 userInfo = JsonConvert.DeserializeObject<UserInfoDto>(apiResponse.Result.ToString());
                 return userInfo;
             }
             return userInfo;
+        }
+
+        public async Task<UserInfoDto> GetUser()
+        {
+            ApiResponseDto apiResponse = await _httpClient.GetJsonAsync<ApiResponseDto>("api/Account/GetUser");
+            UserInfoDto user = JsonConvert.DeserializeObject<UserInfoDto>(apiResponse.Result.ToString());
+            return user;
         }
 
         public async Task<ApiResponseDto> UpdateUser(UserInfoDto userInfo)

--- a/src/BlazorBoilerplate.Client/Shared/Components/UserProfile.razor
+++ b/src/BlazorBoilerplate.Client/Shared/Components/UserProfile.razor
@@ -1,21 +1,36 @@
 ﻿@using Microsoft.AspNetCore.Components
 @inject IdentityAuthenticationStateProvider authStateProvider
 
-@if (IsLoggedIn)
-{
-    <div class="drawer-profile">
-        <MatIconButton Icon="account_circle" Link="/account/profile"></MatIconButton>
-        <span class="miniHover"><b><a href="/account/profile">@userInfo.UserName</a></b></span>
-    </div>
-}
+<AuthorizeView>
+    <Authorized>
+        <div class="drawer-profile">
+            <MatIconButton Icon="account_circle" Link="/account/profile"></MatIconButton>
+            @if (userInfo == null)
+            {
+                <div class="spinner-border spinner-border-sm" role="status"></div>
+            }
+            else
+            {
+                <span class="miniHover"><b><a href="/account/profile">@userInfo.UserName</a></b></span>
+            }
+        </div>
+    </Authorized>
+</AuthorizeView>
 
 @code {
     public bool IsLoggedIn = false;
     UserInfoDto userInfo = null;
+    [CascadingParameter]
+    Task<AuthenticationState> authenticationStateTask { get; set; }
 
     protected override async Task OnParametersSetAsync()
     {
-        userInfo = await authStateProvider.GetUserInfo();
-        IsLoggedIn = userInfo.IsAuthenticated;
+        userInfo = null;
+        var user = (await authenticationStateTask).User;
+
+        if (user.Identity.IsAuthenticated)
+        {
+            userInfo = await authStateProvider.GetUserInfo();
+        }
     }
 }

--- a/src/BlazorBoilerplate.Client/Shared/Components/UserProfile.razor
+++ b/src/BlazorBoilerplate.Client/Shared/Components/UserProfile.razor
@@ -1,30 +1,21 @@
 ﻿@using Microsoft.AspNetCore.Components
 @inject IdentityAuthenticationStateProvider authStateProvider
 
-<AuthorizeView Context="AuthorizeContext">
-    <Authorized>
-        <div class="drawer-profile">
-            <MatIconButton Icon="account_circle" Link="/account/profile"></MatIconButton>
-            <span class="miniHover"><b><a href="/account/profile">@userInfo.UserName</a></b></span>
-        </div>
-    </Authorized>
-</AuthorizeView>
+@if (IsLoggedIn)
+{
+    <div class="drawer-profile">
+        <MatIconButton Icon="account_circle" Link="/account/profile"></MatIconButton>
+        <span class="miniHover"><b><a href="/account/profile">@userInfo.UserName</a></b></span>
+    </div>
+}
 
 @code {
     public bool IsLoggedIn = false;
     UserInfoDto userInfo = null;
 
-    [CascadingParameter]
-    Task<AuthenticationState> authenticationStateTask { get; set; }
-
     protected override async Task OnParametersSetAsync()
     {
-        userInfo = null;
-        var user = (await authenticationStateTask).User;
-
-        if (user.Identity.IsAuthenticated)
-        {
-            userInfo = await authStateProvider.GetUserInfo();
-        }
+        userInfo = await authStateProvider.GetUserInfo();
+        IsLoggedIn = userInfo.IsAuthenticated;
     }
 }

--- a/src/BlazorBoilerplate.Client/Shared/Layouts/MainLayout.razor
+++ b/src/BlazorBoilerplate.Client/Shared/Layouts/MainLayout.razor
@@ -90,9 +90,9 @@
         // Set Default landing page if you want
         //navigationManager.NavigateTo("/");
 
-        var user = await authStateProvider.GetUserInfo();
+        var user = (await authenticationStateTask).User;
 
-        if (user.IsAuthenticated)
+        if (user.Identity.IsAuthenticated)
         {
             var profile = await appState.GetUserProfile();
             _navMenuOpened = profile.IsNavOpen;

--- a/src/BlazorBoilerplate.Client/Shared/Layouts/MainLayout.razor
+++ b/src/BlazorBoilerplate.Client/Shared/Layouts/MainLayout.razor
@@ -1,145 +1,146 @@
 ﻿@inherits LayoutComponentBase
 @inject NavigationManager navigationManager
 @inject AppState appState
-     <MatDrawerContainer Style="width: 100vw; height: 100vh;" Class="@bbDrawerClass">
-            <MatDrawer @bind-Opened="@_navMenuOpened">
-                <header class="drawer-header">
-                    <div class="drawer-logo">
-                        <img alt="Blazor Boilerplate" class="logo-img" src="images/blazorboilerplate-dark.svg" title="Blazor Boilerplate">
-                        <a class="miniHover" href="/">Blazor Boilerplate</a>
-                    </div>
-                    <UserProfile />
-                </header>
-                <NavMenu />
-                <footer class="drawer-footer">
-                    <MatTooltip Tooltip="Help">
-                        <MatButton Icon="help" RefBack="@context" Link="https://github.com/enkodellc/blazorboilerplate"><span class="miniHover">Help & Support</span></MatButton>
-                    </MatTooltip>
-                </footer>
-            </MatDrawer>
-            <MatDrawerContent>
-                <MatAppBarContainer>
-                    <MatAppBar Fixed="true">
-                        <MatAppBarRow>
-                            <MatAppBarSection>
-                                <MatAppBarTitle>
+@inject IdentityAuthenticationStateProvider authStateProvider
 
-                                </MatAppBarTitle>
-                                <div class="hidden-mdc-down">
+<MatDrawerContainer Style="width: 100vw; height: 100vh;" Class="@bbDrawerClass">
+    <MatDrawer @bind-Opened="@_navMenuOpened">
+        <header class="drawer-header">
+            <div class="drawer-logo">
+                <img alt="Blazor Boilerplate" class="logo-img" src="images/blazorboilerplate-dark.svg" title="Blazor Boilerplate">
+                <a class="miniHover" href="/">Blazor Boilerplate</a>
+            </div>
+            <UserProfile />
+        </header>
+        <NavMenu />
+        <footer class="drawer-footer">
+            <MatTooltip Tooltip="Help">
+                <MatButton Icon="help" RefBack="@context" Link="https://github.com/enkodellc/blazorboilerplate"><span class="miniHover">Help & Support</span></MatButton>
+            </MatTooltip>
+        </footer>
+    </MatDrawer>
+    <MatDrawerContent>
+        <MatAppBarContainer>
+            <MatAppBar Fixed="true">
+                <MatAppBarRow>
+                    <MatAppBarSection>
+                        <MatAppBarTitle>
+                        </MatAppBarTitle>
+                        <div class="hidden-mdc-down">
                             @*<nav>
                                 <ul>
                                     <li>*@
-    <MatTooltip Tooltip="Toggle Navigation">
-        <MatIconButton Class="navToggle" Icon="menu" ToggleIcon="menu" OnClick="@((e) => NavToggle())" RefBack="@context"></MatIconButton>
-    </MatTooltip>
+                            <MatTooltip Tooltip="Toggle Navigation">
+                                <MatIconButton Class="navToggle" Icon="menu" ToggleIcon="menu" OnClick="@((e) => NavToggle())" RefBack="@context"></MatIconButton>
+                            </MatTooltip>
                             @*</li>
                                 <li>*@
-    <MatTooltip Tooltip="Minify Navigation">
-        <MatIconButton Class="navToggle" Icon="format_indent_decrease" ToggleIcon="format_indent_increase" OnClick="@((e) => NavMinify())" RefBack="@context"></MatIconButton>
-    </MatTooltip>
+                            <MatTooltip Tooltip="Minify Navigation">
+                                <MatIconButton Class="navToggle" Icon="format_indent_decrease" ToggleIcon="format_indent_increase" OnClick="@((e) => NavMinify())" RefBack="@context"></MatIconButton>
+                            </MatTooltip>
                             @*</li>
                                 <li>
-                                    <MatTooltip Tooltip="Lock Navigation" >
+                                    <MatTooltip Tooltip="Lock Navigation">
                                         <MatIconButton Class="navToggle" Icon="lock" ToggleIcon="radio_button_unchecked" OnClick="@((e) => NavLock())" RefBack="@context"></MatIconButton>
                                     </MatTooltip>
                                     </li>*@
                             @*</ul>
                                 </nav>*@
-                            </div>
-                        </MatAppBarSection>
-    <MatAppBarSection Align="@MatAppBarSectionAlign.End">
-        <MatTooltip Tooltip="Donate to Support">
-            <MatIconButton Link="https://www.paypal.me/enkodellc" RefBack="@context"><i class="fa fa-cc-paypal"></i></MatIconButton>
-        </MatTooltip>
-        <MatTooltip Tooltip="Github Repository">
-            <MatIconButton Link="https://github.com/enkodellc/blazorboilerplate" RefBack="@context"><i class="fa fa-github" aria-hidden="true"></i></MatIconButton>
-        </MatTooltip>
-        <Login></Login>
-    </MatAppBarSection>
-                    </MatAppBarRow>
-                </MatAppBar>
-    <MatAppBarContent>
-        <Breadcrumbs RootLinkTitle="Home"></Breadcrumbs>
-        <section class="container-fluid">
-            @Body
-        </section>
-        <footer class="page-footer">
-            <div class="flex-1">
-                © 2019 <a href="//blazorboilerplate.com">Blazor Boilerplate</a> Version 0.5.0 - Developed by <a href="https://keithfimreite.com" target="_blank">Enkode LLC</a>
-            </div>
-        </footer>
-    </MatAppBarContent>
-            </MatAppBarContainer>
-        </MatDrawerContent>
-    </MatDrawerContainer>
+                        </div>
+                    </MatAppBarSection>
+                    <MatAppBarSection Align="@MatAppBarSectionAlign.End">
+                        <MatTooltip Tooltip="Donate to Support">
+                            <MatIconButton Link="https://www.paypal.me/enkodellc" RefBack="@context"><i class="fa fa-cc-paypal"></i></MatIconButton>
+                        </MatTooltip>
+                        <MatTooltip Tooltip="Github Repository">
+                            <MatIconButton Link="https://github.com/enkodellc/blazorboilerplate" RefBack="@context"><i class="fa fa-github" aria-hidden="true"></i></MatIconButton>
+                        </MatTooltip>
+                        <Login></Login>
+                    </MatAppBarSection>
+                </MatAppBarRow>
+            </MatAppBar>
+            <MatAppBarContent>
+                <Breadcrumbs RootLinkTitle="Home"></Breadcrumbs>
+                <section class="container-fluid">
+                    @Body
+                </section>
+                <footer class="page-footer">
+                    <div class="flex-1">
+                        © 2019 <a href="//blazorboilerplate.com">Blazor Boilerplate</a> Version 0.5.0 - Developed by <a href="https://keithfimreite.com" target="_blank">Enkode LLC</a>
+                    </div>
+                </footer>
+            </MatAppBarContent>
+        </MatAppBarContainer>
+    </MatDrawerContent>
+</MatDrawerContainer>
 
-    @code {
-        bool _navMenuOpened = true;
-        bool _navMinified = false;
-        public string bbDrawerClass = "";
+@code {
+    bool _navMenuOpened = true;
+    bool _navMinified = false;
+    public string bbDrawerClass = "";
 
-        [CascadingParameter]
-        Task<AuthenticationState> authenticationStateTask { get; set; }
+    [CascadingParameter]
+    Task<AuthenticationState> authenticationStateTask { get; set; }
 
-        protected override async Task OnInitializedAsync()
+    protected override async Task OnInitializedAsync()
+    {
+        // Uncomment to secure entire app
+        //navigationManager.NavigateTo("/account/login");
+
+        // Set Default landing page if you want
+        //navigationManager.NavigateTo("/");
+
+        var user = await authStateProvider.GetUserInfo();
+
+        if (user.IsAuthenticated)
         {
-            // Uncomment to secure entire app
-            //navigationManager.NavigateTo("/account/login");
-
-            // Set Default landing page if you want
-            //navigationManager.NavigateTo("/");
-
-            var user = (await authenticationStateTask).User;
-
-            if (user.Identity.IsAuthenticated)
-            {
-                var profile = await appState.GetUserProfile();
-                _navMenuOpened = profile.IsNavOpen;
-                _navMinified = profile.IsNavMinified;
-                // navigationManager.NavigateTo(AppState.UserProfile.LastPageVisited); //Not Implemented
-            }
-        }
-
-        void NavToggle()
-        {
-            _navMenuOpened = !_navMenuOpened;
-            if (_navMenuOpened)
-            {
-                bbDrawerClass = "full";
-            }
-            else
-            {
-                bbDrawerClass = "closed";
-            }
-
-            this.StateHasChanged();
-        }
-
-        void NavLock()
-        {
-            //Todo Lock Nav
-        }
-
-        void NavMinify()
-        {
-            _navMinified = !_navMinified;
-
-            if (!_navMenuOpened)
-            {
-                _navMinified = true;
-            }
-
-            if (_navMinified)
-            {
-                bbDrawerClass = "mini";
-                _navMenuOpened = true;
-            }
-            else if (_navMenuOpened)
-            {
-                bbDrawerClass = "full";
-            }
-
-            _navMenuOpened = true;
-            this.StateHasChanged();
+            var profile = await appState.GetUserProfile();
+            _navMenuOpened = profile.IsNavOpen;
+            _navMinified = profile.IsNavMinified;
+            // navigationManager.NavigateTo(AppState.UserProfile.LastPageVisited); //Not Implemented
         }
     }
+
+    void NavToggle()
+    {
+        _navMenuOpened = !_navMenuOpened;
+        if (_navMenuOpened)
+        {
+            bbDrawerClass = "full";
+        }
+        else
+        {
+            bbDrawerClass = "closed";
+        }
+
+        this.StateHasChanged();
+    }
+
+    void NavLock()
+    {
+        //Todo Lock Nav
+    }
+
+    void NavMinify()
+    {
+        _navMinified = !_navMinified;
+
+        if (!_navMenuOpened)
+        {
+            _navMinified = true;
+        }
+
+        if (_navMinified)
+        {
+            bbDrawerClass = "mini";
+            _navMenuOpened = true;
+        }
+        else if (_navMenuOpened)
+        {
+            bbDrawerClass = "full";
+        }
+
+        _navMenuOpened = true;
+        this.StateHasChanged();
+    }
+}

--- a/src/BlazorBoilerplate.Server/Controllers/AccountController.cs
+++ b/src/BlazorBoilerplate.Server/Controllers/AccountController.cs
@@ -57,10 +57,8 @@ namespace BlazorBoilerplate.Server.Controllers
             _db = db;
         }
 
-
         // POST: api/Account/Login
         [HttpPost("Login")]
-
         [AllowAnonymous]
         [ProducesResponseType(204)]
         [ProducesResponseType(401)]
@@ -104,7 +102,6 @@ namespace BlazorBoilerplate.Server.Controllers
             return new ApiResponse(401, "Login Failed");
         }
 
-
         // POST: api/Account/Register
         [HttpPost("Register")]
         [AllowAnonymous]
@@ -146,7 +143,6 @@ namespace BlazorBoilerplate.Server.Controllers
             }
         }
 
-
         // POST: api/Account/ConfirmEmail
         [HttpPost("ConfirmEmail")]
         [AllowAnonymous]
@@ -182,7 +178,6 @@ namespace BlazorBoilerplate.Server.Controllers
             return new ApiResponse(200, "Success");
         }
 
-
         // POST: api/Account/ForgotPassword
         [HttpPost("ForgotPassword")]
         [AllowAnonymous]
@@ -202,6 +197,7 @@ namespace BlazorBoilerplate.Server.Controllers
             }
 
             #region Forgot Password Email
+
             try
             {
                 // For more information on how to enable account confirmation and password reset please visit http://go.microsoft.com/fwlink/?LinkID=532713
@@ -220,7 +216,9 @@ namespace BlazorBoilerplate.Server.Controllers
             {
                 _logger.LogInformation("Forgot Password email failed: {0}", ex.Message);
             }
-            #endregion
+
+            #endregion Forgot Password Email
+
             return new ApiResponse(200, "Success");
         }
 
@@ -242,19 +240,22 @@ namespace BlazorBoilerplate.Server.Controllers
             }
 
             #region Reset Password Successful Email
+
             try
             {
                 IdentityResult result = await _userManager.ResetPasswordAsync(user, parameters.Token, parameters.Password);
                 if (result.Succeeded)
                 {
                     #region Email Successful Password change
+
                     var email = new EmailMessageDto();
                     email.ToAddresses.Add(new EmailAddressDto(user.Email, user.Email));
                     email.BuildPasswordResetEmail(user.UserName); //Replace First UserName with Name if you want to add name to Registration Form
 
                     _logger.LogInformation("Reset Password Successful Email Sent: {0}", user.Email);
                     await _emailService.SendEmailAsync(email);
-                    #endregion
+
+                    #endregion Email Successful Password change
 
                     return new ApiResponse(200, String.Format("Reset Password Successful Email Sent: {0}", user.Email));
                 }
@@ -268,9 +269,9 @@ namespace BlazorBoilerplate.Server.Controllers
             {
                 _logger.LogInformation("Reset Password failed: {0}", ex.Message);
                 return new ApiResponse(400, string.Format("Error while resetting the password!: {0}", ex.Message));
-
             }
-            #endregion
+
+            #endregion Reset Password Successful Email
         }
 
         // POST: api/Account/Logout
@@ -359,7 +360,6 @@ namespace BlazorBoilerplate.Server.Controllers
             return new ApiResponse(200, "User Updated Successfully");
         }
 
-
         ///----------Admin User Management Interface Methods
 
         // POST: api/Account/Create
@@ -402,6 +402,7 @@ namespace BlazorBoilerplate.Server.Controllers
                 if (Convert.ToBoolean(_configuration["BlazorBoilerplate:RequireConfirmedEmail"] ?? "false"))
                 {
                     #region New  User Confirmation Email
+
                     try
                     {
                         // For more information on how to enable account confirmation and password reset please visit http://go.microsoft.com/fwlink/?LinkID=532713
@@ -419,11 +420,14 @@ namespace BlazorBoilerplate.Server.Controllers
                     {
                         _logger.LogInformation("New user email failed: {0}", ex.Message);
                     }
-                    #endregion
+
+                    #endregion New  User Confirmation Email
+
                     return new ApiResponse(200, "Create User Success");
                 }
 
                 #region New  User Email
+
                 try
                 {
                     var email = new EmailMessageDto();
@@ -437,7 +441,8 @@ namespace BlazorBoilerplate.Server.Controllers
                 {
                     _logger.LogInformation("New user email failed: {0}", ex.Message);
                 }
-                #endregion
+
+                #endregion New  User Email
 
                 UserInfoDto userInfo = new UserInfoDto
                 {
@@ -488,9 +493,7 @@ namespace BlazorBoilerplate.Server.Controllers
             }
         }
 
-
         [HttpGet("GetUser")]
-        [Authorize]
         public ApiResponse GetUser()
         {
             UserInfoDto userInfo = User != null && User.Identity.IsAuthenticated
@@ -554,7 +557,6 @@ namespace BlazorBoilerplate.Server.Controllers
                     foreach (var role in rolesToAdd)
                     {
                         await _userManager.AddClaimAsync(appUser, new Claim($"Is{role}", "true")).ConfigureAwait(true);
-
                     }
 
                     foreach (var role in currentUserRoles)

--- a/src/BlazorBoilerplate.Server/Controllers/AccountController.cs
+++ b/src/BlazorBoilerplate.Server/Controllers/AccountController.cs
@@ -284,7 +284,6 @@ namespace BlazorBoilerplate.Server.Controllers
         }
 
         [HttpGet("UserInfo")]
-        [Authorize]
         [ProducesResponseType(200)]
         [ProducesResponseType(401)]
         public async Task<ApiResponse> UserInfo()


### PR DESCRIPTION
In order to get rid of the 401 error reported in #102 I suggest the following changes:

1. Removing _userInfoCache from the athorization cycle.
2. Bring GetUser into the cycle. It seems that it is much safer to give an unauthorized access to GetUser than GetUserInfo.

some other changes applied to pages and components to be compatible with the new structure.