### PR TITLE
AuthorizationPolicyProvider based authorization

### DIFF
--- a/src/BlazorBoilerplate.CommonUI/Pages/Admin/Roles.razor
+++ b/src/BlazorBoilerplate.CommonUI/Pages/Admin/Roles.razor
@@ -55,7 +55,7 @@ else
             </div>
         </fieldset>
 
-        <MatTable Items="@permissionsSelections" Class="mat-elevation-z5" ShowPaging="false">
+        <MatTable Items="@permissionsSelections" Class="mat-elevation-z5" ShowPaging="true">
             <MatTableHeader>
                 <th>Permissions</th>
                 <th>Allow</th>

--- a/src/BlazorBoilerplate.CommonUI/Pages/Admin/Roles.razor
+++ b/src/BlazorBoilerplate.CommonUI/Pages/Admin/Roles.razor
@@ -1,5 +1,5 @@
 @page "/admin/roles"
-@attribute [Authorize]
+@attribute [Authorize(Permissions.Role.Read)]
 @inject HttpClient Http
 @inject IAuthorizationService AuthorizationService
 @inject AuthenticationStateProvider authStateProvider
@@ -20,15 +20,23 @@ else
     <MatTable Class="mat-elevation-z5" Items="@roles" LoadInitialData="true" Striped="true" RequestApiOnlyOnce="true" ApiUrl="api/roles"
               DebounceMilliseconds="150">
         <MatTableHeader>
-            <th><MatButton Icon="add" Label="New Role" OnClick="@(() => OpenUpsertRoleDialog())"></MatButton></th>
+            <th>
+                <AuthorizeView Policy="@Permissions.Role.Create">
+                    <MatButton Icon="add" Label="New Role" OnClick="@(() => OpenUpsertRoleDialog())"></MatButton>
+                </AuthorizeView>
+            </th>
             <th>Name</th>
             <th>Permissions</th>
         </MatTableHeader>
         <MatTableRow Context="RoleRow">
             <td>
                 <div style="width:155px;">
-                    <MatIconButton Icon="edit" OnClick="@(() => OpenUpsertRoleDialog(@RoleRow.Name))"></MatIconButton>
-                    <MatIconButton Icon="delete" OnClick="@(() => OpenDeleteDialog(@RoleRow.Name))"></MatIconButton>
+                    <AuthorizeView Policy="@Permissions.Role.Update">
+                        <MatIconButton Icon="edit" OnClick="@(() => OpenUpsertRoleDialog(@RoleRow.Name))"></MatIconButton>
+                    </AuthorizeView>
+                    <AuthorizeView Policy="@Permissions.Role.Delete">
+                        <MatIconButton Icon="delete" OnClick="@(() => OpenDeleteDialog(@RoleRow.Name))"></MatIconButton>
+                    </AuthorizeView>
                 </div>
             </td>
             <td><div style="width:130px;">@RoleRow.Name</div></td>

--- a/src/BlazorBoilerplate.Server/Authorization/AuthorizationPolicyProvider.cs
+++ b/src/BlazorBoilerplate.Server/Authorization/AuthorizationPolicyProvider.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace BlazorBoilerplate.Server.Authorization
+{
+    public class AuthorizationPolicyProvider : DefaultAuthorizationPolicyProvider
+    {
+        private readonly AuthorizationOptions _options;
+
+        public AuthorizationPolicyProvider(IOptions<AuthorizationOptions> options) : base(options)
+        {
+            _options = options.Value;
+        }
+
+        public override async Task<AuthorizationPolicy> GetPolicyAsync(string policyName)
+        {
+            // Check static policies first
+            var policy = await base.GetPolicyAsync(policyName);
+
+            if (policy == null)
+            {
+                policy = new AuthorizationPolicyBuilder()
+                    .AddRequirements(new PermissionRequirement(policyName))
+                    .Build();
+
+                // Add policy to the AuthorizationOptions, so we don't have to re-create it each time
+                _options.AddPolicy(policyName, policy);
+            }
+
+            return policy;
+        }
+    }
+}

--- a/src/BlazorBoilerplate.Server/Authorization/AuthorizationPolicyProvider.cs
+++ b/src/BlazorBoilerplate.Server/Authorization/AuthorizationPolicyProvider.cs
@@ -24,6 +24,7 @@ namespace BlazorBoilerplate.Server.Authorization
             if (policy == null)
             {
                 policy = new AuthorizationPolicyBuilder()
+                    .RequireAuthenticatedUser()
                     .AddRequirements(new PermissionRequirement(policyName))
                     .Build();
 

--- a/src/BlazorBoilerplate.Server/Authorization/PermissionRequirement.cs
+++ b/src/BlazorBoilerplate.Server/Authorization/PermissionRequirement.cs
@@ -1,0 +1,92 @@
+﻿using BlazorBoilerplate.Server.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace BlazorBoilerplate.Server.Authorization
+{
+    public class PermissionRequirement : IAuthorizationRequirement
+    {
+        public PermissionRequirement(string permission)
+        {
+            Permission = permission;
+        }
+
+        public string Permission { get; set; }
+    }
+    public class PermissionRequirementHandler : AuthorizationHandler<PermissionRequirement>,
+        IAuthorizationRequirement
+
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly RoleManager<IdentityRole<Guid>> _roleManager;
+
+        public PermissionRequirementHandler(UserManager<ApplicationUser> userManager,
+            RoleManager<IdentityRole<Guid>> roleManager)
+        {
+            _userManager = userManager;
+            _roleManager = roleManager;
+        }
+
+        protected override async Task HandleRequirementAsync(
+            AuthorizationHandlerContext context,
+            PermissionRequirement requirement)
+        {
+            if (context.User == null)
+            {
+                return;
+            }
+
+            ApplicationUser user = await _userManager.GetUserAsync(context.User);
+            if (user == null)
+            {
+                return;
+            }
+
+            List<Claim> roleClaims = await BuildRoleClaims(user);
+
+            if (roleClaims.FirstOrDefault(c => c.Value == requirement.Permission) != null)
+            {
+                context.Succeed(requirement);
+            }
+        }
+        public async Task<List<Claim>> BuildRoleClaims(ApplicationUser user)
+        {
+            List<Claim> roleClaims = new List<Claim>();
+            if (_userManager.SupportsUserRole)
+            {
+                IList<string> roles = await _userManager.GetRolesAsync(user);
+                foreach (string roleName in roles)
+                {
+                    if (_roleManager.SupportsRoleClaims)
+                    {
+                        IdentityRole<Guid> role = await _roleManager.FindByNameAsync(roleName);
+                        if (role != null)
+                        {
+                            IList<Claim> rc = await _roleManager.GetClaimsAsync(role);
+                            roleClaims.AddRange(rc.ToList());
+                        }
+                    }
+                    roleClaims = roleClaims.Distinct(new ClaimsComparer()).ToList();
+                }
+            }
+            return roleClaims;
+        }
+        public class ClaimsComparer : IEqualityComparer<Claim>
+        {
+            public bool Equals(Claim x, Claim y)
+            {
+                return x.Value == y.Value;
+            }
+            public int GetHashCode(Claim claim)
+            {
+                int claimValue = claim.Value?.GetHashCode() ?? 0;
+                return claimValue;
+            }
+        }
+    }
+}

--- a/src/BlazorBoilerplate.Server/Authorization/PermissionRequirement.cs
+++ b/src/BlazorBoilerplate.Server/Authorization/PermissionRequirement.cs
@@ -53,6 +53,10 @@ namespace BlazorBoilerplate.Server.Authorization
             {
                 context.Succeed(requirement);
             }
+            else
+            {
+                context.Fail();
+            }
         }
         public async Task<List<Claim>> BuildRoleClaims(ApplicationUser user)
         {

--- a/src/BlazorBoilerplate.Server/Authorization/PermissionRequirement.cs
+++ b/src/BlazorBoilerplate.Server/Authorization/PermissionRequirement.cs
@@ -45,7 +45,6 @@ namespace BlazorBoilerplate.Server.Authorization
                 return;
             }
 
-            //List<Claim> roleClaims = await BuildRoleClaims(user);
             var roleClaims = from ur in _context.UserRoles
                          where ur.UserId == user.Id
                          join r in _context.Roles on ur.RoleId equals r.Id

--- a/src/BlazorBoilerplate.Server/Controllers/AccountController.cs
+++ b/src/BlazorBoilerplate.Server/Controllers/AccountController.cs
@@ -365,7 +365,7 @@ namespace BlazorBoilerplate.Server.Controllers
 
         // POST: api/Account/Create
         [HttpPost("Create")]
-        [Authorize(Policy = Policies.IsAdmin)]
+        [Authorize(Permissions.User.Create)]
         public async Task<ApiResponse> Create(RegisterDto parameters)
         {
             try
@@ -467,7 +467,7 @@ namespace BlazorBoilerplate.Server.Controllers
 
         // DELETE: api/Account/5
         [HttpDelete("{id}")]
-        [Authorize(Policy = Policies.IsAdmin)]
+        [Authorize(Permissions.User.Delete)]
         public async Task<ApiResponse> Delete(string id)
         {
             var user = await _userManager.FindByIdAsync(id);
@@ -504,7 +504,7 @@ namespace BlazorBoilerplate.Server.Controllers
         }
 
         [HttpGet("ListRoles")]
-        [Authorize]
+        [Authorize(Permissions.Role.Read)]
         public async Task<ApiResponse> ListRoles()
         {
             var roleList = _roleManager.Roles.Select(x => x.Name).ToList();
@@ -512,7 +512,7 @@ namespace BlazorBoilerplate.Server.Controllers
         }
 
         [HttpPut]
-        [Authorize(Policy = Policies.IsAdmin)]
+        [Authorize(Permissions.User.Update)]
         // PUT: api/Account/5
         public async Task<ApiResponse> Update([FromBody] UserInfoDto userInfo)
         {

--- a/src/BlazorBoilerplate.Server/Controllers/AdminController.cs
+++ b/src/BlazorBoilerplate.Server/Controllers/AdminController.cs
@@ -118,7 +118,7 @@ namespace BlazorBoilerplate.Server.Controllers
         #region GetRoles
 
         [HttpGet("Roles")]
-        [Authorize]
+        [Authorize(Permissions.Role.Read)]
         public async Task<ApiResponse> GetRoles([FromQuery] int pageSize = 10, [FromQuery] int pageNumber = 0)
         {
             var roleDtoList = new List<RoleDto>();
@@ -203,7 +203,7 @@ namespace BlazorBoilerplate.Server.Controllers
         #region CRUD : CreateRoleAsync
 
         [HttpPost("Role")]
-        [Authorize(Policy = Policies.IsAdmin)]
+        [Authorize(Permissions.Role.Create)]
         public async Task<ApiResponse> CreateRoleAsync([FromBody] RoleDto newRole)
         {
             try
@@ -246,7 +246,7 @@ namespace BlazorBoilerplate.Server.Controllers
         #region CRUD : UpdateRoleAsync
 
         [HttpPut("Role")]
-        [Authorize(Policy = Policies.IsAdmin)]
+        [Authorize(Permissions.Role.Update)]
         public async Task<ApiResponse> UpdateRoleAsync([FromBody] RoleDto newRole)
         {
             try
@@ -287,7 +287,7 @@ namespace BlazorBoilerplate.Server.Controllers
 
         // DELETE: api/Admin/Role/5
         [HttpDelete("Role/{name}")]
-        [Authorize(Policy = Policies.IsAdmin)]
+        [Authorize(Permissions.Role.Delete)]
         public async Task<ApiResponse> DeleteRoleAsync(string name)
         {
             try

--- a/src/BlazorBoilerplate.Server/Controllers/ToDoController.cs
+++ b/src/BlazorBoilerplate.Server/Controllers/ToDoController.cs
@@ -68,7 +68,7 @@ namespace BlazorBoilerplate.Server.Controllers
         
         // DELETE: api/Todo/5
         [HttpDelete("{id}")]
-        [Authorize(Policy = Policies.IsAdmin)]
+        [Authorize(Permissions.Todo.Delete)]
         public async Task<ApiResponse> Delete(long id)
         {
             return await _todoService.Delete(id); // Delete from DB

--- a/src/BlazorBoilerplate.Server/Data/Core/ApplicationPermissions.cs
+++ b/src/BlazorBoilerplate.Server/Data/Core/ApplicationPermissions.cs
@@ -25,9 +25,9 @@ namespace BlazorBoilerplate.Server.Data.Core
                     ApplicationPermission applicationPermission = new ApplicationPermission
                     {
                         Value = permission.GetValue(null).ToString(),
+                        Name = permission.GetValue(null).ToString().Replace('.', ' '),
                         GroupName = permissionClass.Name
                     };
-                    applicationPermission.Name = applicationPermission.Value.Replace('.', ' ');
                     DescriptionAttribute[] attributes =
         (DescriptionAttribute[])permission.GetCustomAttributes(
         typeof(DescriptionAttribute),
@@ -40,7 +40,7 @@ namespace BlazorBoilerplate.Server.Data.Core
                     }
                     else
                     {
-                        applicationPermission.Description = applicationPermission.Value;
+                        applicationPermission.Description = applicationPermission.Name;
                     }
 
                     allPermissions.Add(applicationPermission);

--- a/src/BlazorBoilerplate.Server/Data/Core/ApplicationPermissions.cs
+++ b/src/BlazorBoilerplate.Server/Data/Core/ApplicationPermissions.cs
@@ -11,7 +11,7 @@ namespace BlazorBoilerplate.Server.Data.Core
     {
         public static ReadOnlyCollection<ApplicationPermission> AllPermissions;
         /// <summary>
-        /// Generates ApplicationPermissions based on Permissions Type by iterating over nested classes and getting constant strings in each class as Value and Name, DescriptionAttribute of the constant string as Description, the nested class name as GroupName.
+        /// Generates ApplicationPermissions based on Permissions Type by iterating over its nested classes and getting constant strings in each class as Value and Name, DescriptionAttribute of the constant string as Description, the nested class name as GroupName.
         /// </summary>
         static ApplicationPermissions()
         {

--- a/src/BlazorBoilerplate.Server/Data/DatabaseInitializer.cs
+++ b/src/BlazorBoilerplate.Server/Data/DatabaseInitializer.cs
@@ -85,13 +85,21 @@ namespace BlazorBoilerplate.Server.Data
             {
                 const string adminRoleName = "Administrator";
 
-                IdentityRole<Guid> role = await _roleManager.FindByNameAsync(adminRoleName);
+                IdentityRole<Guid> adminRole = await _roleManager.FindByNameAsync(adminRoleName);
                 var AllClaims = ApplicationPermissions.GetAllPermissionValues().Distinct();
-                var RoleClaims = (await _roleManager.GetClaimsAsync(role)).Select(c=>c.Value).ToList();
+                var RoleClaims = (await _roleManager.GetClaimsAsync(adminRole)).Select(c=>c.Value).ToList();
                 var NewClaims = AllClaims.Except(RoleClaims);
                 foreach (string claim in NewClaims)
                 {
-                    await _roleManager.AddClaimAsync(role, new Claim(ClaimConstants.Permission, claim));
+                    await _roleManager.AddClaimAsync(adminRole, new Claim(ClaimConstants.Permission, claim));
+                }
+                var DeprecatedClaims = RoleClaims.Except(AllClaims);
+                foreach (string claim in DeprecatedClaims)
+                {
+                    foreach(var role in _roleManager.Roles)
+                    {
+                    await _roleManager.RemoveClaimAsync(role, new Claim(ClaimConstants.Permission, claim));
+                    }
                 }
             }
         }

--- a/src/BlazorBoilerplate.Server/Data/DatabaseInitializer.cs
+++ b/src/BlazorBoilerplate.Server/Data/DatabaseInitializer.cs
@@ -94,9 +94,10 @@ namespace BlazorBoilerplate.Server.Data
                     await _roleManager.AddClaimAsync(adminRole, new Claim(ClaimConstants.Permission, claim));
                 }
                 var DeprecatedClaims = RoleClaims.Except(AllClaims);
+                var roles = await _roleManager.Roles.ToListAsync();
                 foreach (string claim in DeprecatedClaims)
                 {
-                    foreach(var role in _roleManager.Roles)
+                    foreach(var role in roles)
                     {
                     await _roleManager.RemoveClaimAsync(role, new Claim(ClaimConstants.Permission, claim));
                     }

--- a/src/BlazorBoilerplate.Server/Data/DatabaseInitializer.cs
+++ b/src/BlazorBoilerplate.Server/Data/DatabaseInitializer.cs
@@ -81,6 +81,19 @@ namespace BlazorBoilerplate.Server.Data
 
                 _logger.LogInformation("Inbuilt account generation completed");
             }
+            else
+            {
+                const string adminRoleName = "Administrator";
+
+                IdentityRole<Guid> role = await _roleManager.FindByNameAsync(adminRoleName);
+                var AllClaims = ApplicationPermissions.GetAllPermissionValues().Distinct();
+                var RoleClaims = (await _roleManager.GetClaimsAsync(role)).Select(c=>c.Value).ToList();
+                var NewClaims = AllClaims.Except(RoleClaims);
+                foreach (string claim in NewClaims)
+                {
+                    await _roleManager.AddClaimAsync(role, new Claim(ClaimConstants.Permission, claim));
+                }
+            }
         }
 
         private async Task SeedBlazorBoilerplateAsync()

--- a/src/BlazorBoilerplate.Server/Startup.cs
+++ b/src/BlazorBoilerplate.Server/Startup.cs
@@ -256,8 +256,9 @@ namespace BlazorBoilerplate.Server
                 options.AddPolicy(Policies.IsReadOnly, Policies.IsReadOnlyPolicy());
                 options.AddPolicy(Policies.IsMyDomain, Policies.IsMyDomainPolicy());  // valid only on serverside operations
             });
-
+            services.AddSingleton<IAuthorizationPolicyProvider, AuthorizationPolicyProvider>();
             services.AddTransient<IAuthorizationHandler, DomainRequirementHandler>();
+            services.AddTransient<IAuthorizationHandler, PermissionRequirementHandler>();
 
             services.Configure<IdentityOptions>(options =>
             {

--- a/src/BlazorBoilerplate.Server/Startup.cs
+++ b/src/BlazorBoilerplate.Server/Startup.cs
@@ -307,7 +307,7 @@ namespace BlazorBoilerplate.Server
                     {
                         if (context.Request.Path.StartsWithSegments("/api"))
                         {
-                            context.Response.StatusCode = (int)(HttpStatusCode.Unauthorized);
+                            context.Response.StatusCode = (int)(HttpStatusCode.Forbidden);// https://stackoverflow.com/a/6937030/2906268
                         }
 
                         return Task.CompletedTask;

--- a/src/BlazorBoilerplate.Shared/AuthorizationDefinitions/Permissions.cs
+++ b/src/BlazorBoilerplate.Shared/AuthorizationDefinitions/Permissions.cs
@@ -1,4 +1,6 @@
-﻿namespace BlazorBoilerplate.Shared.AuthorizationDefinitions
+﻿using System.ComponentModel;
+
+namespace BlazorBoilerplate.Shared.AuthorizationDefinitions
 {
     public static class Actions
     {
@@ -12,23 +14,35 @@
     {
         public static class Todo
         {
+            [Description("Create a new ToDo")]
             public const string Create = nameof(Todo) + "." + nameof(Actions.Create);
+            [Description("Read ToDos")]
             public const string Read = nameof(Todo) + "." + nameof(Actions.Read);
+            [Description("Edit existing ToDos")]
             public const string Update = nameof(Todo) + "." + nameof(Actions.Update);
+            [Description("Delete any ToDo")]
             public const string Delete = nameof(Todo) + "." + nameof(Actions.Delete);
         }
         public static class Role
         {
+            [Description("Create a new Role")]
             public const string Create = nameof(Role) + "." + nameof(Actions.Create);
+            [Description("Read roles data (permissions etc.")]
             public const string Read = nameof(Role) + "." + nameof(Actions.Read);
+            [Description("Edit existing Roles")]
             public const string Update = nameof(Role) + "." + nameof(Actions.Update);
+            [Description("Delete any Role")]
             public const string Delete = nameof(Role) + "." + nameof(Actions.Delete);
         }
         public static class User
         {
+            [Description("Create a new User")]
             public const string Create = nameof(User) + "." + nameof(Actions.Create);
+            [Description("Read Users data (Names, Emails, Phone Numbers, etc.)")]
             public const string Read = nameof(User) + "." + nameof(Actions.Read);
+            [Description("Edit existing users")]
             public const string Update = nameof(User) + "." + nameof(Actions.Update);
+            [Description("Delete any user")]
             public const string Delete = nameof(User) + "." + nameof(Actions.Delete);
         }
     }

--- a/src/BlazorBoilerplate.Shared/AuthorizationDefinitions/Permissions.cs
+++ b/src/BlazorBoilerplate.Shared/AuthorizationDefinitions/Permissions.cs
@@ -45,5 +45,10 @@ namespace BlazorBoilerplate.Shared.AuthorizationDefinitions
             [Description("Delete any user")]
             public const string Delete = nameof(User) + "." + nameof(Actions.Delete);
         }
+        public static class WeatherForecasts
+        {
+            [Description("Read Weather Forecasts")]
+            public const string Read = nameof(WeatherForecasts) + "." + nameof(Actions.Read);
+        }
     }
 }

--- a/src/BlazorBoilerplate.Shared/AuthorizationDefinitions/Permissions.cs
+++ b/src/BlazorBoilerplate.Shared/AuthorizationDefinitions/Permissions.cs
@@ -27,7 +27,7 @@ namespace BlazorBoilerplate.Shared.AuthorizationDefinitions
         {
             [Description("Create a new Role")]
             public const string Create = nameof(Role) + "." + nameof(Actions.Create);
-            [Description("Read roles data (permissions etc.")]
+            [Description("Read roles data (permissions, etc.")]
             public const string Read = nameof(Role) + "." + nameof(Actions.Read);
             [Description("Edit existing Roles")]
             public const string Update = nameof(Role) + "." + nameof(Actions.Update);

--- a/src/BlazorBoilerplate.Shared/AuthorizationDefinitions/Permissions.cs
+++ b/src/BlazorBoilerplate.Shared/AuthorizationDefinitions/Permissions.cs
@@ -1,0 +1,35 @@
+﻿namespace BlazorBoilerplate.Shared.AuthorizationDefinitions
+{
+    public static class Actions
+    {
+        public const string Create = nameof(Create);
+        public const string Read = nameof(Read);
+        public const string Update = nameof(Update);
+        public const string Delete = nameof(Delete);
+    }
+
+    public static class Permissions
+    {
+        public static class Todo
+        {
+            public const string Create = nameof(Todo) + "." + nameof(Actions.Create);
+            public const string Read = nameof(Todo) + "." + nameof(Actions.Read);
+            public const string Update = nameof(Todo) + "." + nameof(Actions.Update);
+            public const string Delete = nameof(Todo) + "." + nameof(Actions.Delete);
+        }
+        public static class Role
+        {
+            public const string Create = nameof(Role) + "." + nameof(Actions.Create);
+            public const string Read = nameof(Role) + "." + nameof(Actions.Read);
+            public const string Update = nameof(Role) + "." + nameof(Actions.Update);
+            public const string Delete = nameof(Role) + "." + nameof(Actions.Delete);
+        }
+        public static class User
+        {
+            public const string Create = nameof(User) + "." + nameof(Actions.Create);
+            public const string Read = nameof(User) + "." + nameof(Actions.Read);
+            public const string Update = nameof(User) + "." + nameof(Actions.Update);
+            public const string Delete = nameof(User) + "." + nameof(Actions.Delete);
+        }
+    }
+}


### PR DESCRIPTION
In this PR I suggest a new authorization infrastructure defined as types and constants and provided as a custom authorization policy by [AuthorizationPolicyProvider](https://docs.microsoft.com/en-us/aspnet/core/security/authorization/iauthorizationpolicyprovider?view=aspnetcore-3.1). 

Main parts:

- **AuthorizationPolicyProvider.cs** : Provides a policy based on a `policyName` we give to authorization system, by using AuthorizeAttribute like this: `[Authorize(policyName)]`. The `policyName` will be just the name of the permission we want to check if the user holds as a claim. Hence, the policy requires the authenticated user to fulfill `PermissionRequirement`.
- **PermissionRequirement.cs** : Checks if the user's role holds a claim of type `permission` with a value equal to the policyName explained above. It does this with a single query so it is fast and thread-safe.
- **Permissions.cs** : We here define the permissions used in our application as some nested classes containing some constant strings. The nested classes can be names of modules, models, etc., and they must contain some permissions as constant strings with **unique** values. So easiest thing to make sure they are unique is to tie them to `nameof` their parent classes. Each "permission" can have a `[DescriptionAttribute(...)]` as description.
- **ApplicationPermissions.cs** : This is the tricky part of this PR. I rewrote ctor of the `ApplicationPermissions` class based on `Permissions` class. Using reflections, the ctor extracts the nested types of `Permissions` class and iterates over their constant (Literal) fields to create a `ApplicationPermission`:
    

    - **Value**: The "permission" value.
    - **Name**: Same as Value.
    - **GroupName**: The nested class name which is the name of modules or models.
    - **Description**: `DescriptionAttribute` value. If not defined we get the Name.

- **DatabaseInitializer.cs** : I added a condition where inbuilt roles are defined, gets current permissions structure and in case we had changed `Permissions.cs`, adds the new permissions to the administrator role, and removes the deprecated ones from all roles. These are optional.

- **Startup.cs**: The last but not the least. We add `AuthorizationPolicyProvider` as a singleton service. Also I propose to change 401 Unauthorized code on authorization failure to 403 Forbidden code. See [this](https://stackoverflow.com/a/6937030/2906268).

After doing so we can use our brand new "Permissions" anywhere and enjoy intellisense and evade typo mistakes. What we would miss if we used magic strings. 

As an example, in UI we can add some authorization checks to role management page using `AuthorizeView `. Therefore, users without `Role.Delete` permission can not even see the delete button.