### PR TITLE
Restructure - Startup errors

### DIFF
--- a/src/BlazorBoilerplate.Server/Startup.cs
+++ b/src/BlazorBoilerplate.Server/Startup.cs
@@ -50,6 +50,8 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Serilog;
+using System.Reflection;
+using Microsoft.AspNetCore.Components.Authorization;
 
 namespace BlazorBoilerplate.Server
 {
@@ -80,7 +82,6 @@ namespace BlazorBoilerplate.Server
                 ? Configuration.GetConnectionString("DefaultConnection")
                 : $"Filename={Configuration.GetConnectionString("SqlLiteConnectionFileName")}";
 
-            var authAuthority = Configuration["BlazorBoilerplate:IS4ApplicationUrl"].TrimEnd('/');
 
             void DbContextOptionsBuilder(DbContextOptionsBuilder builder)
             {

--- a/src/BlazorBoilerplate.Storage/ServiceCollectionExtensions.cs
+++ b/src/BlazorBoilerplate.Storage/ServiceCollectionExtensions.cs
@@ -22,12 +22,7 @@ namespace BlazorBoilerplate.Storage
             services.AddTransient<IUserProfileStore, UserProfileStore>();
             services.AddTransient<IToDoStore, ToDoStore>();
             services.AddTransient<IApiLogStore, ApiLogStore>();
-            
-            services.AddIdentity<ApplicationUser, IdentityRole<Guid>>()
-                .AddRoles<IdentityRole<Guid>>()
-                .AddEntityFrameworkStores<ApplicationDbContext>()
-                .AddDefaultTokenProviders();
-            
+                       
             services.AddTransient<IDatabaseInitializer, DatabaseInitializer>();
             
             return services;


### PR DESCRIPTION
I received several startup errors when trying to run the restructure branch:

Some using statements ins Startup.cs were missing and one variable was declared twice.
Also this:

            services.AddIdentity<ApplicationUser, IdentityRole<Guid>>()
                .AddRoles<IdentityRole<Guid>>()
                .AddEntityFrameworkStores<ApplicationDbContext>()
                .AddDefaultTokenProviders();

was in Startup.cs and ServiceCollectionExtensions.cs which causes:

2020-03-09 23:03:05.528 +01:00 [FTL] Application startup exception
System.InvalidOperationException: Scheme already exists: Identity.Application
   at Microsoft.AspNetCore.Authentication.AuthenticationOptions.AddScheme(String name, Action`1 configureBuilder)
   at Microsoft.AspNetCore.Authentication.AuthenticationBuilder.<>c__DisplayClass4_0`2.<AddSchemeHelper>b__0(AuthenticationOptions o)
   at Microsoft.Extensions.Options.ConfigureNamedOptions`1.Configure(String name, TOptions options)
   at Microsoft.Extensions.Options.OptionsFactory`1.Create(String name)
...

I made some changes. The project is now starting up.
Please verify that you have the same issue before merging this PR.

Cheers