### PR TITLE
bump sdk version to 3.1.200 and switch to UseDotNet@2 task

### DIFF
--- a/BlazorBoilerplate.Server.Tests/BlazorBoilerplate.Server.Tests.csproj
+++ b/BlazorBoilerplate.Server.Tests/BlazorBoilerplate.Server.Tests.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0-preview-20200309-01" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0-preview-20200310-03" />
   </ItemGroup>
 
   <ItemGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,30 +4,37 @@
 # https://docs.microsoft.com/azure/devops/pipelines/apps/aspnet/build-aspnet-4
 
 pool:
-  vmImage: 'vs2017-win2016'
+  vmImage: 'windows-2019'
 
 variables:
   solution: '**/*.sln'
   buildPlatform: 'Any CPU'
-  buildConfiguration: 'Release_CSB'
+  buildConfiguration_CSB: 'Release_CSB'
+  buildConfiguration_SSB: 'Release_SSB'
+
 
 steps:
-- task: DotNetCoreInstaller@0
+- task: UseDotNet@2
   displayName: 'Install SDK'
   inputs:
-    version: '3.1.100-preview3-014645'
+    packageType: sdk
+    version: '3.1.x'
+    includePreviewVersions: true
 
-- task: NuGetToolInstaller@0
+# - task: NuGetToolInstaller@0
 
-- script: dotnet build ./src/BlazorBoilerplate.sln --configuration $(buildConfiguration)
-  displayName: 'dotnet build blazorboilerplate'
+- script: dotnet build ./src/BlazorBoilerplate.sln --configuration $(buildConfiguration_CSB)
+  displayName: 'dotnet build blazorboilerplate ClientSide'
+
+- script: dotnet build ./src/BlazorBoilerplate.sln --configuration $(buildConfiguration_SSB)
+  displayName: 'dotnet build blazorBoilerplate ServerSide'
 
 - task: DotNetCoreCLI@2
-  displayName: 'Publishing App...'
+  displayName: 'Publishing ClientSide App...'
   inputs:
     command: publish
     publishWebProjects: true
-    arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)'
+    arguments: '--configuration $(buildConfiguration_CSB) --output $(Build.ArtifactStagingDirectory)'
     zipAfterPublish: false
 
 - task: PublishBuildArtifacts@1

--- a/src/BlazorBoilerplate.CommonUI/BlazorBoilerplate.CommonUI.csproj
+++ b/src/BlazorBoilerplate.CommonUI/BlazorBoilerplate.CommonUI.csproj
@@ -38,12 +38,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MatBlazor" Version="2.2.0-preview" />
+    <PackageReference Include="MatBlazor" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="3.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
-    <PackageReference Include="Toolbelt.Blazor.LoadingBar" Version="11.0.0" />
+    <PackageReference Include="Toolbelt.Blazor.LoadingBar" Version="11.0.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BlazorBoilerplate.Server/BlazorBoilerplate.Server.csproj
+++ b/src/BlazorBoilerplate.Server/BlazorBoilerplate.Server.csproj
@@ -52,7 +52,7 @@
     <PackageReference Include="MatBlazor" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="3.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="3.2.0-preview2.20160.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="3.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="3.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.0" />

--- a/src/BlazorBoilerplate.Server/BlazorBoilerplate.Server.csproj
+++ b/src/BlazorBoilerplate.Server/BlazorBoilerplate.Server.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="IdentityServer4" Version="3.1.2" />
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
     <PackageReference Include="IdentityServer4.AspNetIdentity" Version="3.1.0" />
-    <PackageReference Include="MatBlazor" Version="2.0.0" />
+    <PackageReference Include="MatBlazor" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="3.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="3.2.0-preview2.20160.5" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="3.1.1" />

--- a/src/BlazorBoilerplate.Server/BlazorBoilerplate.Server.csproj
+++ b/src/BlazorBoilerplate.Server/BlazorBoilerplate.Server.csproj
@@ -59,7 +59,7 @@
     <PackageReference Include="NSwag.AspNetCore" Version="13.2.2" />
     <PackageReference Include="IdentityServer4.EntityFramework" Version="3.1.2" />
     <PackageReference Include="IdentityServer4.AspNetIdentity" Version="3.1.2" />
-    <PackageReference Include="MatBlazor" Version="2.2.0-preview" />
+    <PackageReference Include="MatBlazor" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="3.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="3.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
@@ -86,7 +86,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="3.3.0-dev-00152" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.1-dev-00216" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0-dev-00864" />
-    <PackageReference Include="MailKit" Version="2.5.1" />
+    <PackageReference Include="MailKit" Version="2.5.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BlazorBoilerplate.Storage/BlazorBoilerplate.Storage.csproj
+++ b/src/BlazorBoilerplate.Storage/BlazorBoilerplate.Storage.csproj
@@ -6,9 +6,9 @@
 
     <ItemGroup>
       <PackageReference Include="AutoMapper" Version="9.0.0" />
-      <PackageReference Include="IdentityServer4" Version="3.1.0" />
-      <PackageReference Include="IdentityServer4.EntityFramework" Version="3.1.0" />
-      <PackageReference Include="IdentityServer4.EntityFramework.Storage" Version="3.1.0" />
+      <PackageReference Include="IdentityServer4" Version="3.1.2" />
+      <PackageReference Include="IdentityServer4.EntityFramework" Version="3.1.2" />
+      <PackageReference Include="IdentityServer4.EntityFramework.Storage" Version="3.1.2" />
       <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.2" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.2" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.2" />


### PR DESCRIPTION
splitting the pipeline changes off from #197 into its own pull req
Basically the same as #200 but with the addition of building both ssb and csb variants (only publishes csb though)