### PR TITLE
Dev db log viewer

### DIFF
--- a/src/BlazorBoilerplate.CommonUI/Pages/DbLogViewer.razor
+++ b/src/BlazorBoilerplate.CommonUI/Pages/DbLogViewer.razor
@@ -1,15 +1,15 @@
-﻿@page "/dBlog_viewer"
-@*@attribute [Authorize(Policy =Policies.IsAdmin)]*@
+﻿@page "/admin/dBlogViewer"
 
+@attribute [Authorize(Policy = Policies.IsAdmin)]
 @inject HttpClient Http
 @inject IMatToaster matToaster
 @using BlazorBoilerplate.Shared.DataModels
 @using static Microsoft.AspNetCore.Http.StatusCodes
-@using System.Xml;
 
 <h1>Serilog MSSqlDb Log Viewer</h1>
 <p>
-
+    Secured Page.<br />
+    Paginated viewing and fetching of system logs from the database.
 </p>
 
 @if (apiResponses == null)
@@ -20,18 +20,24 @@
 }
 else
 {
-    <MatTable Items="@dBLogItems" Class="mat-elevation-z5" Striped="true" PageSizeParamName="pageSize">
+    <div class="row">
+        <div class="font-weight-bold">Refresh Timer:</div>
+        <RefreshTimer ElapsedEvent="@(async (_, __) => await LoadData())" />
+    </div>
+    <MatPaginator PageSize="@pageSize" Page="@(async a=> await OnPage(a))" Length="@logCountTotal">
+
+    </MatPaginator>
+    <MatTable Items="@dBLogItems" Class="mat-elevation-z5" Striped="true" PageSize="@pageSize" ShowPaging="false">
         <MatTableHeader>
-            <th><div style="width:175px;"><MatFAB Icon="refresh" OnClick="@(async () => await LoadData())" Raised="true" Mini="true" Style="margin-right:16px;"></MatFAB> Timestamp</div></th>
-            <th>Loging Level</th>
+            <th><div style="max-width:165px;">@*<MatSlideToggle Value="@timer.Enabled" ValueChanged="@(a=>UpdateTimer(a))" TValue="bool" Style="margin-right:16px;"></MatSlideToggle>*@ Timestamp</div></th>
+            <th>Logging Level</th>
             <th>Log Message</th>
             <th>Exception (if any)</th>
-            <th>Properties recorded with log Entry</th>
-
+            <th>Recorded Properties</th>
         </MatTableHeader>
         <MatTableRow>
-            <td>@context.TimeStamp.ToString()</td>
-            <td>@context.Level</td>
+            <td><span style="font-size:small">@context.TimeStamp.ToString()</span></td>
+            <td><span style="font-size:small">@context.Level</span></td>
             <td><span style="font-size:small">@context.Message</span></td>
             <td><span style="font-size:small">@context.Exception?.ToString()</span></td>
             <td>
@@ -40,13 +46,16 @@ else
                     <ul>
                         @foreach (var propertyPair in context.LogProperties)
                             {
-                            <li style="font-size:small">@($"{propertyPair.Key}:  {propertyPair.Value}"))</li>
+                            <li style="font-size:small">@($"{propertyPair.Key}:  {propertyPair.Value}")</li>
                             }
+                    
                     </ul>
                     }
+              
             </td>
         </MatTableRow>
     </MatTable>
+
 }
 
 
@@ -55,22 +64,28 @@ else
     List<DbLog> dBLogItems = new List<DbLog>();
 
     private int pageSize { get; set; } = 10;
+    private int pageIndex { get; set; } = 0;
+    private int logCountTotal { get; set; } = 0;
 
     protected override async Task OnInitializedAsync()
     {
         await LoadData();
+   
     }
-
-    protected async Task PaginationWrapperAsync(int page)
+    async Task OnPage(MatPaginatorPageEvent e)
     {
+        pageSize = e.PageSize;
+        pageIndex = e.PageIndex;
+
+        await LoadData().ConfigureAwait(true);
 
     }
-    protected async Task LoadData(int page = 0)
+    protected async Task LoadData()
     {
         ApiResponseDto apiResponse = null;
         try
         {
-            apiResponse = await Http.GetJsonAsync<ApiResponseDto>($"api/DbLog?page={page}&pageSize={this.pageSize}");
+            apiResponse = await Http.GetJsonAsync<ApiResponseDto>($"api/DbLog?page={this.pageIndex}&pageSize={this.pageSize}");
 
         }
         catch (Exception ex)
@@ -82,9 +97,12 @@ else
         if (apiResponse.StatusCode == Status200OK)
         {
 
-            matToaster.Add(apiResponse.Message, MatToastType.Success, "Api Log Items Retrieved");
+            matToaster.Add(apiResponse.Message, MatToastType.Success, "DB Log Items Retrieved");
             var nextPage = Newtonsoft.Json.JsonConvert.DeserializeObject<DbLog[]>(apiResponse.Result.ToString()).ToList<DbLog>();
-            dBLogItems.AddRange(nextPage);
+            this.logCountTotal = apiResponse.PaginationDetails.CollectionSize;
+            this.dBLogItems = nextPage;
+
+            //dBLogItems.AddRange(nextPage);
         }
         else if (apiResponse.StatusCode == Status204NoContent)
         {
@@ -93,8 +111,10 @@ else
         }
         else
         {
-            matToaster.Add(apiResponse.Message, MatToastType.Danger, "Api Log Items Retrieval Failed");
+            matToaster.Add(apiResponse.Message, MatToastType.Danger, "DB Log Items Retrieval Failed");
         }
+        await InvokeAsync(StateHasChanged).ConfigureAwait(true);
+
     }
 
 

--- a/src/BlazorBoilerplate.CommonUI/Pages/DbLogViewer.razor
+++ b/src/BlazorBoilerplate.CommonUI/Pages/DbLogViewer.razor
@@ -1,0 +1,102 @@
+﻿@page "/dBlog_viewer"
+@*@attribute [Authorize(Policy =Policies.IsAdmin)]*@
+
+@inject HttpClient Http
+@inject IMatToaster matToaster
+@using BlazorBoilerplate.Shared.DataModels
+@using static Microsoft.AspNetCore.Http.StatusCodes
+@using System.Xml;
+
+<h1>Serilog MSSqlDb Log Viewer</h1>
+<p>
+
+</p>
+
+@if (apiResponses == null)
+{
+    <LoadingBackground ShowLogoBox="true">
+        <label>Loading SQL Log Data</label>
+    </LoadingBackground>
+}
+else
+{
+    <MatTable Items="@dBLogItems" Class="mat-elevation-z5" Striped="true" PageSizeParamName="pageSize">
+        <MatTableHeader>
+            <th><div style="width:175px;"><MatFAB Icon="refresh" OnClick="@(async () => await LoadData())" Raised="true" Mini="true" Style="margin-right:16px;"></MatFAB> Timestamp</div></th>
+            <th>Loging Level</th>
+            <th>Log Message</th>
+            <th>Exception (if any)</th>
+            <th>Properties recorded with log Entry</th>
+
+        </MatTableHeader>
+        <MatTableRow>
+            <td>@context.TimeStamp.ToString()</td>
+            <td>@context.Level</td>
+            <td><span style="font-size:small">@context.Message</span></td>
+            <td><span style="font-size:small">@context.Exception?.ToString()</span></td>
+            <td>
+                @if (context.LogProperties?.Any() ?? false)
+                    {
+                    <ul>
+                        @foreach (var propertyPair in context.LogProperties)
+                            {
+                            <li style="font-size:small">@($"{propertyPair.Key}:  {propertyPair.Value}"))</li>
+                            }
+                    </ul>
+                    }
+            </td>
+        </MatTableRow>
+    </MatTable>
+}
+
+
+@code {
+    ApiResponseDto[] apiResponses = new ApiResponseDto[] { };
+    List<DbLog> dBLogItems = new List<DbLog>();
+
+    private int pageSize { get; set; } = 10;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadData();
+    }
+
+    protected async Task PaginationWrapperAsync(int page)
+    {
+
+    }
+    protected async Task LoadData(int page = 0)
+    {
+        ApiResponseDto apiResponse = null;
+        try
+        {
+            apiResponse = await Http.GetJsonAsync<ApiResponseDto>($"api/DbLog?page={page}&pageSize={this.pageSize}");
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex);
+            throw;
+        }
+
+        if (apiResponse.StatusCode == Status200OK)
+        {
+
+            matToaster.Add(apiResponse.Message, MatToastType.Success, "Api Log Items Retrieved");
+            var nextPage = Newtonsoft.Json.JsonConvert.DeserializeObject<DbLog[]>(apiResponse.Result.ToString()).ToList<DbLog>();
+            dBLogItems.AddRange(nextPage);
+        }
+        else if (apiResponse.StatusCode == Status204NoContent)
+        {
+            matToaster.Add(String.Empty, MatToastType.Info, "No more logs to fetch");
+
+        }
+        else
+        {
+            matToaster.Add(apiResponse.Message, MatToastType.Danger, "Api Log Items Retrieval Failed");
+        }
+    }
+
+
+
+}

--- a/src/BlazorBoilerplate.CommonUI/Pages/DbLogViewer.razor
+++ b/src/BlazorBoilerplate.CommonUI/Pages/DbLogViewer.razor
@@ -20,8 +20,7 @@
 }
 else
 {
-    <div class="row">
-        <div class="font-weight-bold">Refresh Timer:</div>
+    <div class="row" style="margin-left: 0;">
         <RefreshTimer ElapsedEvent="@(async (_, __) => await LoadData())" />
     </div>
     <MatPaginator PageSize="@pageSize" Page="@(async a=> await OnPage(a))" Length="@logCountTotal">
@@ -48,10 +47,10 @@ else
                             {
                             <li style="font-size:small">@($"{propertyPair.Key}:  {propertyPair.Value}")</li>
                             }
-                    
+
                     </ul>
                     }
-              
+
             </td>
         </MatTableRow>
     </MatTable>
@@ -70,7 +69,7 @@ else
     protected override async Task OnInitializedAsync()
     {
         await LoadData();
-   
+
     }
     async Task OnPage(MatPaginatorPageEvent e)
     {
@@ -85,7 +84,7 @@ else
         ApiResponseDto apiResponse = null;
         try
         {
-            apiResponse = await Http.GetJsonAsync<ApiResponseDto>($"api/DbLog?page={this.pageIndex}&pageSize={this.pageSize}");
+            apiResponse = await Http.GetFromJsonAsync<ApiResponseDto>($"api/DbLog?page={this.pageIndex}&pageSize={this.pageSize}");
 
         }
         catch (Exception ex)
@@ -96,7 +95,6 @@ else
 
         if (apiResponse.StatusCode == Status200OK)
         {
-
             matToaster.Add(apiResponse.Message, MatToastType.Success, "DB Log Items Retrieved");
             var nextPage = Newtonsoft.Json.JsonConvert.DeserializeObject<DbLog[]>(apiResponse.Result.ToString()).ToList<DbLog>();
             this.logCountTotal = apiResponse.PaginationDetails.CollectionSize;

--- a/src/BlazorBoilerplate.CommonUI/Pages/_Imports.razor
+++ b/src/BlazorBoilerplate.CommonUI/Pages/_Imports.razor
@@ -1,2 +1,3 @@
 ﻿@layout MainLayout
 @using MatBlazor
+@using System.Net.Http.Json

--- a/src/BlazorBoilerplate.CommonUI/Shared/Components/NavMenu.razor
+++ b/src/BlazorBoilerplate.CommonUI/Shared/Components/NavMenu.razor
@@ -65,6 +65,9 @@
                         <MatNavItem Href="@navigationManager.ToAbsoluteUri("admin/roles").AbsoluteUri">
                             <MatIcon>supervisor_account</MatIcon> <span class="miniHover">Roles</span>
                         </MatNavItem>
+                        <MatNavItem Href="@navigationManager.ToAbsoluteUri("admin/dBlogViewer").AbsoluteUri">
+                            <MatIcon>notes</MatIcon> <span class="miniHover">DB Logging View</span>
+                        </MatNavItem>
                     </MatNavSubMenuList>
                 </MatNavSubMenu>
             </Authorized>

--- a/src/BlazorBoilerplate.CommonUI/Shared/Components/RefreshTimer.razor
+++ b/src/BlazorBoilerplate.CommonUI/Shared/Components/RefreshTimer.razor
@@ -1,0 +1,56 @@
+﻿@implements IDisposable
+@using System.Timers
+
+<div class="row">
+    <div class="align-self-center justify-content-center">
+        <MatSlideToggle @bind-Value="timer.Enabled" />
+    </div>   
+    <div>
+        <MatNumericUpDownField Label="@Text"
+                               Value="@Interval"
+                               ValueChanged="@UpdateInterval"
+                               DecimalPlaces="0"
+                               Dense="true"
+                               Minimum="1"
+                               TValue="double">
+
+        </MatNumericUpDownField>
+    </div>
+</div>
+@code {
+
+    private Timer timer = new Timer();
+
+
+    /// <summary>
+    /// Delegate invoked on timer interval
+    /// </summary>
+    [Parameter] public ElapsedEventHandler ElapsedEvent { get;set;}
+
+  
+    [Parameter] public string Text { get;set;} = "Seconds";
+
+    /// <summary>
+    /// Timer Interval Value in Seconds. Defaults to 5
+    /// </summary>
+    [Parameter] public double Interval {get;set; } = 5;
+    protected override void OnInitialized()
+    {
+
+        timer.Enabled = false;
+        timer.Interval = Interval * 1000;
+        timer.Elapsed += ElapsedEvent;
+        base.OnInitialized();
+
+    }
+    void UpdateInterval(double newInterval)
+    {
+        Interval = newInterval;
+        timer.Interval = newInterval * 1000; //convert to milliseconds
+    }
+    public void Dispose()
+    {
+        timer.Elapsed -= ElapsedEvent;
+        timer.Dispose();
+    }
+}

--- a/src/BlazorBoilerplate.CommonUI/Shared/Components/RefreshTimer.razor
+++ b/src/BlazorBoilerplate.CommonUI/Shared/Components/RefreshTimer.razor
@@ -1,11 +1,13 @@
 ﻿@implements IDisposable
 @using System.Timers
 
-<div class="row">
-    <div class="align-self-center justify-content-center">
-        <MatSlideToggle @bind-Value="timer.Enabled" />
-    </div>   
+<div class="refresh-timer row">
+
+    <div>@Label</div>
     <div>
+        <MatSlideToggle @bind-Value="timer.Enabled" />
+    </div>
+    <div class="refresh-timer-interval-wrapper">
         <MatNumericUpDownField Label="@Text"
                                Value="@Interval"
                                ValueChanged="@UpdateInterval"
@@ -25,15 +27,20 @@
     /// <summary>
     /// Delegate invoked on timer interval
     /// </summary>
-    [Parameter] public ElapsedEventHandler ElapsedEvent { get;set;}
+    [Parameter] public ElapsedEventHandler ElapsedEvent { get; set; }
 
-  
-    [Parameter] public string Text { get;set;} = "Seconds";
+    /// <summary>
+    /// Text Placed to the left of the interval selection dropdown.
+    /// Defaults to 'Refresh Interval: .
+    /// </summary>
+    [Parameter]
+    public string Label { get; set; } = "Refresh Interval: ";
+    [Parameter] public string Text { get; set; } = "Seconds";
 
     /// <summary>
     /// Timer Interval Value in Seconds. Defaults to 5
     /// </summary>
-    [Parameter] public double Interval {get;set; } = 5;
+    [Parameter] public double Interval { get; set; } = 5;
     protected override void OnInitialized()
     {
 

--- a/src/BlazorBoilerplate.CommonUI/wwwroot/css/site.css
+++ b/src/BlazorBoilerplate.CommonUI/wwwroot/css/site.css
@@ -753,3 +753,27 @@ ul.breadcrumb {
 .mat-toast-close-button .material-icons {
     color: white;
 }
+
+/*Refresh Timer*/
+div.refresh-timer.row {
+    margin-left: 0;
+    margin-right: 0;
+    -moz-align-content: center;
+    -o-align-content: center;
+    -webkit-align-content: center;
+    align-content: center;
+    -o-justify-content: center;
+    -webkit-justify-content: center;
+    justify-content: center;
+
+}
+div.refresh-timer.row div {
+    -webkit-align-self: center;
+    -o-align-self: center;
+    align-self: center;
+    margin-left: .2rem;
+    margin-right: .2rem;
+}
+div.refresh-timer-interval-wrapper {
+    width: 100px;
+}

--- a/src/BlazorBoilerplate.Server/Controllers/DbLogController.cs
+++ b/src/BlazorBoilerplate.Server/Controllers/DbLogController.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using BlazorBoilerplate.Shared.DataModels;
+using BlazorBoilerplate.Storage;
+using BlazorBoilerplate.Server.Managers;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Authorization;
+using BlazorBoilerplate.Shared.AuthorizationDefinitions;
+using BlazorBoilerplate.Server.Middleware.Wrappers;
+using System.Linq.Expressions;
+
+namespace BlazorBoilerplate.Server.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    [AllowAnonymous]
+    // [Authorize(Policy=Policies.IsAdmin)]
+    public class DbLogController : ControllerBase
+    {
+        private readonly IDbLogManager _dbLogManager;
+        private readonly ILogger<DbLogController> _logger;
+
+        public DbLogController(IDbLogManager dbLogManager, ILogger<DbLogController> logger)
+        {
+            _dbLogManager = dbLogManager;
+            _logger = logger;
+        }
+
+        // GET: api/Logs
+        [HttpGet]
+        public async Task<ActionResult<ApiResponse>> GetLogs([FromQuery]int pageSize, [FromQuery] int page)
+        {
+            // TODO: Implement an api-safe client selector // filtering
+            Expression<Func<DbLog, bool>> predicate = _=>  true;
+                //placeholder
+
+
+            return await _dbLogManager.Get(pageSize, page, predicate).ConfigureAwait(false);
+        }
+
+    }
+}

--- a/src/BlazorBoilerplate.Server/Controllers/DbLogController.cs
+++ b/src/BlazorBoilerplate.Server/Controllers/DbLogController.cs
@@ -18,8 +18,7 @@ namespace BlazorBoilerplate.Server.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]
-    [AllowAnonymous]
-    // [Authorize(Policy=Policies.IsAdmin)]
+    [Authorize(Policy=Policies.IsAdmin)]
     public class DbLogController : ControllerBase
     {
         private readonly IDbLogManager _dbLogManager;
@@ -37,7 +36,7 @@ namespace BlazorBoilerplate.Server.Controllers
         {
             // TODO: Implement an api-safe client selector // filtering
             Expression<Func<DbLog, bool>> predicate = _=>  true;
-                //placeholder
+                //placeholder for selector
 
 
             return await _dbLogManager.Get(pageSize, page, predicate).ConfigureAwait(false);

--- a/src/BlazorBoilerplate.Server/Helpers/RegexUtilities.cs
+++ b/src/BlazorBoilerplate.Server/Helpers/RegexUtilities.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace BlazorBoilerplate.Server.Helpers
+{
+    public static class RegexUtilities
+    {
+        public static Regex StringInterpolationHelper = new Regex("(?<=[\\ \"]{0,1}{)(.+?)(?=})(?:[\\ \\.\"]{0,2}|$)", RegexOptions.Compiled, TimeSpan.FromMilliseconds(100));
+
+        internal static Regex DirtyXMLParserRegex = new Regex("(?<=<property key=\')(?<key>[a-zA-Z0-9\\- :]+?)(?:'>)(?<value>[a-zA-Z0-9. \\/-:]+?)(?=<\\/property>)", RegexOptions.Compiled);
+
+        public static Dictionary<string, string> DirtyXMLParser(string input)
+        {
+            var propertyList = new Dictionary<string, string>();
+            var xmlMatch = DirtyXMLParserRegex.Match(input);
+            while (xmlMatch.Success)
+            {
+                propertyList.Add(xmlMatch.Groups["key"].Value, xmlMatch.Groups["value"].Value);
+                xmlMatch = xmlMatch.NextMatch();
+            }
+            return propertyList;
+        }
+    }
+}

--- a/src/BlazorBoilerplate.Server/Helpers/RegexUtilities.cs
+++ b/src/BlazorBoilerplate.Server/Helpers/RegexUtilities.cs
@@ -8,14 +8,16 @@ namespace BlazorBoilerplate.Server.Helpers
 {
     public static class RegexUtilities
     {
-        public static Regex StringInterpolationHelper = new Regex("(?<=[\\ \"]{0,1}{)(.+?)(?=})(?:[\\ \\.\"]{0,2}|$)", RegexOptions.Compiled, TimeSpan.FromMilliseconds(100));
+        public static readonly Regex StringInterpolationHelper = new Regex("(?<=[\\ \"]{0,1}{)(.+?)(?=})(?:[\\ \\.\"]{0,2}|$)", RegexOptions.Compiled, TimeSpan.FromMilliseconds(100));
 
-        internal static Regex DirtyXMLParserRegex = new Regex("(?<=<property key=\')(?<key>[a-zA-Z0-9\\- :]+?)(?:'>)(?<value>[a-zA-Z0-9. \\/-:]+?)(?=<\\/property>)", RegexOptions.Compiled);
+        //[a-zA-Z0-9.+= \\/-:]
+        private static readonly Regex DirtyXmlPropertyParserRegex = new Regex("(?<=<property key=\')(?<key>[a-zA-Z0-9\\- :]+?)(?:'>)(?<value>[^><]+?)(?=<\\/property>)", RegexOptions.Compiled, TimeSpan.FromMilliseconds(100));
 
-        public static Dictionary<string, string> DirtyXMLParser(string input)
+        
+        public static Dictionary<string, string> DirtyXmlPropertyParser(string input)
         {
             var propertyList = new Dictionary<string, string>();
-            var xmlMatch = DirtyXMLParserRegex.Match(input);
+            var xmlMatch = DirtyXmlPropertyParserRegex.Match(input);
             while (xmlMatch.Success)
             {
                 propertyList.Add(xmlMatch.Groups["key"].Value, xmlMatch.Groups["value"].Value);

--- a/src/BlazorBoilerplate.Server/Managers/DbLogManager.cs
+++ b/src/BlazorBoilerplate.Server/Managers/DbLogManager.cs
@@ -1,0 +1,115 @@
+﻿using BlazorBoilerplate.Server.Middleware.Wrappers;
+using BlazorBoilerplate.Shared.DataModels;
+using BlazorBoilerplate.Storage;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using static Microsoft.AspNetCore.Http.StatusCodes;
+using System.Threading.Tasks;
+using System.Linq.Expressions;
+using System.Xml;
+using System.Text;
+using BlazorBoilerplate.Server.Helpers;
+
+namespace BlazorBoilerplate.Server.Managers
+{
+    public class DbLogManager : IDbLogManager
+    {
+        private readonly ApplicationDbContext _dbContext;
+        private readonly ILogger<DbLogManager> _logger;
+
+        public DbLogManager(ApplicationDbContext context, ILogger<DbLogManager> logger)
+        {
+            _dbContext = context;
+            _logger = logger;
+        }
+
+        public async Task<ApiResponse> Get(int pageSize = 25, int page = 0, Expression<Func<DbLog, bool>> predicate = null)
+        {
+
+            try
+            {
+                var r = await _dbContext.Logs.Where(predicate).Skip(pageSize * page).Take(pageSize).ToArrayAsync().ConfigureAwait(false);
+                if (r.Length == 0)
+                {
+                    return new ApiResponse(Status204NoContent, $"No results for request; pageSize ={ pageSize}; page ={ page}");
+                }
+                else
+                {
+                    foreach (var item in r)
+                    {
+                        var PropertyDict = RegexUtilities.DirtyXMLParser(item.Properties);
+                        item.LogProperties = PropertyDict;
+
+                    }
+                    //return new ApiResponse(Status200OK, "", formattedMessageList);
+                    return new ApiResponse(Status200OK, $"Retrieved Type=DbLog;pageSize={pageSize};page={page}", r);
+
+
+                }
+
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(ex, "Error while retrieving Db Logs");
+                return new ApiResponse(Status500InternalServerError, "Error while retrieving Db Logs", null);
+            }
+        }
+        protected static System.IO.MemoryStream GenerateStreamFromString(string value)
+        {
+            return new System.IO.MemoryStream(System.Text.Encoding.UTF8.GetBytes(value ?? ""));
+        }
+        protected async Task<System.IO.Stream> GetStreamFromStringAsync(string inputString)
+        {
+            using var stream = new System.IO.MemoryStream();
+            using var writer = new System.IO.StreamWriter(stream);
+            await writer.WriteAsync(inputString).ConfigureAwait(true);
+            await writer.FlushAsync();
+            stream.Position = 0;
+            return stream;
+        }
+        protected string ExtractPropertiesFromLog(DbLog log)
+        {
+
+            XmlReaderSettings settings = new XmlReaderSettings
+            {
+                Async = true
+            };
+
+            var PropertyDict = new Dictionary<string, string>();
+            try
+            {
+
+                PropertyDict = RegexUtilities.DirtyXMLParser(log.Properties);
+                if (PropertyDict.Count == 0)
+                    return log.MessageTemplate;
+
+
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+
+            var s = new StringBuilder(log.MessageTemplate);
+            var match = Helpers.RegexUtilities.StringInterpolationHelper.Match(log.MessageTemplate);
+            while (match.Success)
+            {
+                if (PropertyDict.ContainsKey(match.Value))
+                    s.Replace($"{{{match.Value}}}", PropertyDict[match.Value]);
+                match = match.NextMatch();
+
+            }
+            return s.ToString();
+        }
+
+
+        public Task Log(DbLog LogItem)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/BlazorBoilerplate.Server/Managers/IDbLogManager.cs
+++ b/src/BlazorBoilerplate.Server/Managers/IDbLogManager.cs
@@ -5,12 +5,13 @@ using System.Linq;
 using System.Threading.Tasks;
 using BlazorBoilerplate.Shared.DataModels;
 using System.Linq.Expressions;
+using System.Threading;
 
 namespace BlazorBoilerplate.Server.Managers
 {
     public interface IDbLogManager
     {
         Task Log(DbLog LogItem);
-        Task<ApiResponse> Get(int pageSize, int page, Expression<Func<DbLog, bool>> predicate = null);
+        Task<ApiResponse> Get(int pageSize, int page, Expression<Func<DbLog, bool>> predicate = null, CancellationToken cancellationToken = default);
     }
 }

--- a/src/BlazorBoilerplate.Server/Managers/IDbLogManager.cs
+++ b/src/BlazorBoilerplate.Server/Managers/IDbLogManager.cs
@@ -1,0 +1,16 @@
+﻿using BlazorBoilerplate.Server.Middleware.Wrappers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BlazorBoilerplate.Shared.DataModels;
+using System.Linq.Expressions;
+
+namespace BlazorBoilerplate.Server.Managers
+{
+    public interface IDbLogManager
+    {
+        Task Log(DbLog LogItem);
+        Task<ApiResponse> Get(int pageSize, int page, Expression<Func<DbLog, bool>> predicate = null);
+    }
+}

--- a/src/BlazorBoilerplate.Server/Middleware/Wrappers/APIResponse.cs
+++ b/src/BlazorBoilerplate.Server/Middleware/Wrappers/APIResponse.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using BlazorBoilerplate.Shared.DataModels;
+using Newtonsoft.Json;
 using System;
 using System.Reflection;
 using System.Runtime.Serialization;
@@ -27,8 +28,13 @@ namespace BlazorBoilerplate.Server.Middleware.Wrappers
         [DataMember(EmitDefaultValue = false)]
         public object Result { get; set; }
 
+        [DataMember(EmitDefaultValue = false)]
+        public PaginationDetails PaginationDetails { get; set; }
+
+
+
         [JsonConstructor]
-        public ApiResponse(int statusCode, string message = "", object result = null, ApiError apiError = null, string apiVersion = "")
+        public ApiResponse(int statusCode, string message = "", object result = null, ApiError apiError = null, string apiVersion = "", PaginationDetails paginationDetails = null)
         {
             StatusCode = statusCode;
             Message = message;
@@ -36,6 +42,7 @@ namespace BlazorBoilerplate.Server.Middleware.Wrappers
             ResponseException = apiError;
             Version = string.IsNullOrWhiteSpace(apiVersion) ? Assembly.GetEntryAssembly().GetName().Version.ToString() : apiVersion;
             IsError = false;
+            PaginationDetails = paginationDetails;
         }
 
         public ApiResponse(int statusCode, ApiError apiError)

--- a/src/BlazorBoilerplate.Server/Startup.cs
+++ b/src/BlazorBoilerplate.Server/Startup.cs
@@ -350,11 +350,14 @@ namespace BlazorBoilerplate.Server
             services.AddTransient<IAccountManager, AccountManager>();
             services.AddTransient<IAdminManager, AdminManager>();
             services.AddTransient<IApiLogManager, ApiLogManager>();
+            services.AddTransient<IDbLogManager, DbLogManager>();
             services.AddTransient<IEmailManager, EmailManager>();
             services.AddTransient<IExternalAuthManager, ExternalAuthManager>(); // Currently not being used.
             services.AddTransient<IMessageManager, MessageManager>();
             services.AddTransient<ITodoManager, ToDoManager>();
             services.AddTransient<IUserProfileManager, UserProfileManager>();
+
+
 
             //Automapper to map DTO to Models https://www.c-sharpcorner.com/UploadFile/1492b1/crud-operations-using-automapper-in-mvc-application/
             var automapperConfig = new MapperConfiguration(configuration =>
@@ -420,7 +423,7 @@ namespace BlazorBoilerplate.Server
             {
                 var databaseInitializer = serviceScope.ServiceProvider.GetService<IDatabaseInitializer>();
                 databaseInitializer.SeedAsync().Wait();
-            }            
+            }
 
             // A REST API global exception handler and response wrapper for a consistent API
             // Configure API Loggin in appsettings.json - Logs most API calls. Great for debugging and user activity audits

--- a/src/BlazorBoilerplate.Server/Startup.cs
+++ b/src/BlazorBoilerplate.Server/Startup.cs
@@ -347,6 +347,8 @@ namespace BlazorBoilerplate.Server
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             services.AddSingleton<IEmailConfiguration>(Configuration.GetSection("EmailConfiguration").Get<EmailConfiguration>());
 
+
+            services.AddTransient<IDbLogManager, DbLogManager>();
             services.AddTransient<ITenantManager, TenantManager>();
             services.AddTransient<IAccountManager, AccountManager>();
             services.AddTransient<IAdminManager, AdminManager>();

--- a/src/BlazorBoilerplate.Server/appsettings.json
+++ b/src/BlazorBoilerplate.Server/appsettings.json
@@ -75,12 +75,14 @@
     },
     "WriteTo": [
       {
+        // If you're not using mssql as a backend db either remove this section or just make sure that the target connection string is not blank
+        // Does not throw exception if connection string is invalid, only if it doesn't exist
         "Name": "MSSqlServer", // see https://github.com/serilog/serilog-sinks-mssqlserver/blob/dev/README.md for additional config options
         "Args": {
           "connectionString": "DefaultConnection",
-          "tableName": "Logs2",  // If this is changed, you should also change the table creation method in DatabaseInitializer.cs
+          "tableName": "Logs", // Table Defined in BlazorBoilerplate.Shared/DataModels/Logs.cs
           "autoCreateSqlTable": false,
-          "restrictedToMinimumLevel": "Warning"
+          "restrictedToMinimumLevel": "Information"
         }
       },
       {

--- a/src/BlazorBoilerplate.Shared/DataModels/DbLog.cs
+++ b/src/BlazorBoilerplate.Shared/DataModels/DbLog.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text;
+
+namespace BlazorBoilerplate.Shared.DataModels
+{
+    public class DbLog
+    {
+        [Key]
+        public int Id { get; set; }
+
+        public string Message { get; set; }
+
+        public string MessageTemplate { get; set; }
+
+        public string Level { get; set; }
+
+        public DateTime TimeStamp { get; set; }
+
+        public string Exception { get; set; }
+
+        public string Properties { get; set; }
+
+        [NotMapped]
+        public IDictionary<string, string> LogProperties { get;set;}
+
+    }
+}

--- a/src/BlazorBoilerplate.Shared/DataModels/PaginationDetails.cs
+++ b/src/BlazorBoilerplate.Shared/DataModels/PaginationDetails.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace BlazorBoilerplate.Shared.DataModels
+{
+    /// <summary>
+    /// Standardized details including in paginated responses
+    /// </summary>
+    public class PaginationDetails
+    {
+        public int PageIndex { get; set; }
+
+        public int PageSize { get; set; }
+
+        public int CollectionSize { get; set; }
+    }
+}

--- a/src/BlazorBoilerplate.Shared/Dto/ApiResponseDto.cs
+++ b/src/BlazorBoilerplate.Shared/Dto/ApiResponseDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Serialization;
+﻿using BlazorBoilerplate.Shared.DataModels;
+using System.Runtime.Serialization;
 
 namespace BlazorBoilerplate.Shared.Dto
 {
@@ -21,6 +22,9 @@ namespace BlazorBoilerplate.Shared.Dto
 
         [DataMember(EmitDefaultValue = false)]
         public string ResponseException { get; set; }
+
+        [DataMember(EmitDefaultValue =false)]
+        public PaginationDetails PaginationDetails { get;set;} = null;
 
         [DataMember(EmitDefaultValue = false)]
         public T Result { get; set; }

--- a/src/BlazorBoilerplate.Storage/ApplicationDbContext.cs
+++ b/src/BlazorBoilerplate.Storage/ApplicationDbContext.cs
@@ -25,6 +25,7 @@ namespace BlazorBoilerplate.Storage
         public DbSet<Message> Messages { get; set; }
         public DbSet<Tenant> Tenants { get; set; }
         private IUserSession _userSession { get; set; }
+        public DbSet<DbLog> Logs { get; set; }
 
         public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options, IUserSession userSession) : base(options)
         {

--- a/src/BlazorBoilerplate.Storage/DatabaseInitializer.cs
+++ b/src/BlazorBoilerplate.Storage/DatabaseInitializer.cs
@@ -59,18 +59,6 @@ namespace BlazorBoilerplate.Storage
 
             //Seed blazorboilerplate data
             await SeedBlazorBoilerplateAsync();
-
-
-            // Create Log table so SQL logging works even when target db did not exist on startup
-            try
-            {
-                await EnsureLogTableCreationAsync().ConfigureAwait(false);
-
-            }
-            catch (SqlException sqlException)
-            {
-                _logger.LogError(sqlException, "error while creating sql log table");
-            }
         }
 
         private async Task EnsureLogTableCreationAsync()

--- a/src/BlazorBoilerplate.Storage/DatabaseInitializer.cs
+++ b/src/BlazorBoilerplate.Storage/DatabaseInitializer.cs
@@ -61,35 +61,6 @@ namespace BlazorBoilerplate.Storage
             await SeedBlazorBoilerplateAsync();
         }
 
-        private async Task EnsureLogTableCreationAsync()
-        {
-            // the Serilog SQL logger only works with MSSQL so don't bother if we're not using it
-            if (!_context.Database.IsSqlServer())
-                return;
-
-            // This only works with the default Serilog SQL table layout, primarily a convenience addition
-            // Without this, SQL logging will not work until the project has been started twice (in the case that no db exists initially)
-            using var tr = await _context.Database.BeginTransactionAsync(System.Data.IsolationLevel.Serializable).ConfigureAwait(false);
-            await _context
-                .Database
-                .ExecuteSqlRawAsync("IF (EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = \'dbo\' AND  TABLE_NAME = \'Logs2\'))\r\n" +
-                "PRINT \'Table Exists\';\r\n" +
-                "ELSE\r\n" +
-                "CREATE TABLE [dbo].[Logs2] (\r\n" +
-                "[Id]              INT            IDENTITY (1, 1) NOT NULL,\r\n" +
-                "[Message]         NVARCHAR (MAX) NULL,\r\n" +
-                "[MessageTemplate] NVARCHAR (MAX) NULL,\r\n" +
-                "[Level]           NVARCHAR (MAX) NULL,\r\n" +
-                "[TimeStamp]       DATETIME       NULL,\r\n" +
-                "[Exception]       NVARCHAR (MAX) NULL,\r\n" +
-                "[Properties]      NVARCHAR (MAX) NULL,\r\n" +
-                "CONSTRAINT [PK_Logs2] PRIMARY KEY CLUSTERED ([Id] ASC)\r\n" +
-                ");"
-                 )
-                .ConfigureAwait(false);
-            await tr.CommitAsync().ConfigureAwait(false);
-        }
-
         private async Task MigrateAsync()
         {
             await _context.Database.MigrateAsync().ConfigureAwait(false);

--- a/src/BlazorBoilerplate.Storage/Migrations/20200326012204_DbLogging.Designer.cs
+++ b/src/BlazorBoilerplate.Storage/Migrations/20200326012204_DbLogging.Designer.cs
@@ -4,14 +4,16 @@ using BlazorBoilerplate.Storage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace BlazorBoilerplate.Storage.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200326012204_DbLogging")]
+    partial class DbLogging
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/BlazorBoilerplate.Storage/Migrations/20200326012204_DbLogging.cs
+++ b/src/BlazorBoilerplate.Storage/Migrations/20200326012204_DbLogging.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace BlazorBoilerplate.Storage.Migrations
+{
+    public partial class DbLogging : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Logs",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Message = table.Column<string>(nullable: true),
+                    MessageTemplate = table.Column<string>(nullable: true),
+                    Level = table.Column<string>(nullable: true),
+                    TimeStamp = table.Column<DateTime>(nullable: false),
+                    Exception = table.Column<string>(nullable: true),
+                    Properties = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Logs", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Tenants",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Title = table.Column<string>(maxLength: 128, nullable: false),
+                    OwnerUserId = table.Column<Guid>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Tenants", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Tenants_AspNetUsers_OwnerUserId",
+                        column: x => x.OwnerUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Tenants_OwnerUserId",
+                table: "Tenants",
+                column: "OwnerUserId",
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Logs");
+
+            migrationBuilder.DropTable(
+                name: "Tenants");
+        }
+    }
+}


### PR DESCRIPTION
Db Log Viewer (currently serilog mssql only).
Added Pagination Property to ApiResponse object to facilitate paginated requests (implemented in /admin/bBlogViewier with MatPaginator)

There may be a slight breaking change if people are relying on serilog db logs going to table Logs2 (renamed to Logs and implemented as a C# efcore object) but I only submitted that pull request a few days ago so ¯\_(ツ)_/¯

It's not perfect: the UI could use a little refinement (specifically table column sizing and automatic refresh interval component) and I'd appreciate it if someone could doublecheck my efcore db log query (I'm pretty sure there's a more efficient way of getting ordered logs but I can't think of it now).

It works though
