### PR TITLE
Db Log improvements, fixed accidental migration lumping, delta query support

### DIFF
--- a/src/BlazorBoilerplate.CommonUI/Pages/Admin/DbLogViewer.razor
+++ b/src/BlazorBoilerplate.CommonUI/Pages/Admin/DbLogViewer.razor
@@ -21,9 +21,8 @@
 else
 {
     <div class="row" style="margin-left: 0;">
-        <RefreshTimer ElapsedEvent="@(async (_, __) => await LoadData())" />
+        <RefreshTimer StartEnabled="true" ElapsedEvent="@(async (_, __) => await LoadDeltaMetaAsync())" /> <MatFAB Mini="true" Class="@($"{matfab_animate_class}")" Icon="refresh" OnClick="@LoadDeltaMetaAsync" />
     </div>
-
     <MatTable Items="@dBLogItems" Class="mat-elevation-z5" Striped="true" PageSize="@pageSize" ShowPaging="false">
         <MatTableHeader>
             <th><div style="max-width:165px;">@*<MatSlideToggle Value="@timer.Enabled" ValueChanged="@(a=>UpdateTimer(a))" TValue="bool" Style="margin-right:16px;"></MatSlideToggle>*@ Timestamp</div></th>
@@ -62,7 +61,21 @@ else
     private int pageSize { get; set; } = 10;
     private int pageIndex { get; set; } = 0;
     private int logCountTotal { get; set; } = 0;
+    private int syncPoint { get;set;} = 0;
 
+    string matfab_animate_class = string.Empty;
+    async Task AnimateRefresh()
+    {
+        // this only works every other activation.....
+        if (String.IsNullOrWhiteSpace(matfab_animate_class))
+            matfab_animate_class = "mat-fab-animate";
+        else
+        {
+            matfab_animate_class = String.Empty;
+   
+        }
+
+    }
     protected override async Task OnInitializedAsync()
     {
         await LoadData();
@@ -76,12 +89,52 @@ else
         await LoadData().ConfigureAwait(true);
 
     }
+    protected async Task LoadDeltaMetaAsync()
+    {
+        ApiResponseDto apiResponse = null;
+        var lastEntryId = dBLogItems.Last().Id;
+        try
+        {
+            AnimateRefresh();
+            apiResponse = await Http.GetFromJsonAsync<ApiResponseDto>($"api/DbLog/delta?deltaIndex={syncPoint}");
+
+            if (apiResponse.PaginationDetails.CollectionSizeDelta.HasValue)
+            {
+                if (apiResponse.PaginationDetails.CollectionSizeDelta.Value == 0)
+                {
+                    //Console.WriteLine($"Delta Meta refresh: no items");
+                    return;
+
+                }
+                this.logCountTotal += apiResponse.PaginationDetails.CollectionSizeDelta.Value;
+                this.pageIndex += (apiResponse.PaginationDetails.CollectionSizeDelta.Value / pageSize);
+                if (apiResponse.PaginationDetails.SyncPointReference.HasValue)
+                    this.syncPoint = apiResponse.PaginationDetails.SyncPointReference.Value;
+
+
+                // If the user is looking at something (has changed the page), don't force a data refresh,
+                // else load the new data into view
+                if (this.pageIndex >= 1)
+                    await InvokeAsync(StateHasChanged);
+                else
+                    await LoadData();
+
+            }
+        }
+        catch
+        {
+            matToaster.Add(apiResponse.Message, MatToastType.Danger, "DB Log meta refresh failed");
+
+        }
+    }
     protected async Task LoadData()
     {
         ApiResponseDto apiResponse = null;
         try
         {
             apiResponse = await Http.GetFromJsonAsync<ApiResponseDto>($"api/DbLog?page={this.pageIndex}&pageSize={this.pageSize}");
+            if (apiResponse.PaginationDetails.SyncPointReference.HasValue)
+                this.syncPoint = apiResponse.PaginationDetails.SyncPointReference.Value;
 
         }
         catch (Exception ex)
@@ -92,9 +145,9 @@ else
 
         if (apiResponse.StatusCode == Status200OK)
         {
-            matToaster.Add(apiResponse.Message, MatToastType.Success, "DB Log Items Retrieved");
+            //matToaster.Add(apiResponse.Message, MatToastType.Success, "DB Log Items Retrieved");
             var nextPage = Newtonsoft.Json.JsonConvert.DeserializeObject<DbLog[]>(apiResponse.Result.ToString()).ToList<DbLog>();
-            this.logCountTotal = apiResponse.PaginationDetails.CollectionSize;
+            this.logCountTotal = apiResponse.PaginationDetails.CollectionSize ?? this.logCountTotal;
             this.dBLogItems = nextPage;
 
             //dBLogItems.AddRange(nextPage);

--- a/src/BlazorBoilerplate.CommonUI/Shared/Components/RefreshTimer.razor
+++ b/src/BlazorBoilerplate.CommonUI/Shared/Components/RefreshTimer.razor
@@ -41,10 +41,16 @@
     /// Timer Interval Value in Seconds. Defaults to 5
     /// </summary>
     [Parameter] public double Interval { get; set; } = 5;
+
+
+    /// <summary>
+    /// If the event timer starts off enabled and firing.  Defaults to false.
+    /// </summary>
+    [Parameter] public bool StartEnabled { get;set;} = false;
     protected override void OnInitialized()
     {
 
-        timer.Enabled = false;
+        timer.Enabled = StartEnabled;
         timer.Interval = Interval * 1000;
         timer.Elapsed += ElapsedEvent;
         base.OnInitialized();

--- a/src/BlazorBoilerplate.CommonUI/wwwroot/css/site.css
+++ b/src/BlazorBoilerplate.CommonUI/wwwroot/css/site.css
@@ -507,7 +507,6 @@ ul.breadcrumb {
 /* dialog */
 .mdc-dialog__content {
     min-width: 300px;
-
 }
 
 .mdc-dialog__title + .mdc-dialog__content {
@@ -522,6 +521,7 @@ ul.breadcrumb {
 .mdc-dialog__actions {
     border-top: 1px solid #e1e1e1 !important;
 }
+
 .no-drop {
     border: 2px dashed red;
 }
@@ -595,7 +595,7 @@ ul.breadcrumb {
     color: red;
 }
 
-#blazor-error-ui::before{
+#blazor-error-ui::before {
     margin: auto;
 }
 
@@ -607,7 +607,7 @@ ul.breadcrumb {
 }
 
 #blazor-error-ui {
-    z-index:9999;
+    z-index: 9999;
     display: none;
     background: #fff;
     margin: 0 auto;
@@ -755,8 +755,23 @@ ul.breadcrumb {
 }
 
 .mat-paginator {
-  background: none;
+    background: none;
 }
+
+
+
+.mat-fab-animate {
+    animation: mat_fab_spin 1s linear normal;
+}
+
+@keyframes mat_fab_spin {
+
+    100% {
+        -webkit-transform: rotate(360deg);
+        transform: rotate(360deg);
+    }
+}
+
 
 /*Refresh Timer*/
 div.refresh-timer.row {
@@ -769,15 +784,16 @@ div.refresh-timer.row {
     -o-justify-content: center;
     -webkit-justify-content: center;
     justify-content: center;
+}
 
-}
-div.refresh-timer.row div {
-    -webkit-align-self: center;
-    -o-align-self: center;
-    align-self: center;
-    margin-left: .2rem;
-    margin-right: .2rem;
-}
+    div.refresh-timer.row div {
+        -webkit-align-self: center;
+        -o-align-self: center;
+        align-self: center;
+        margin-left: .2rem;
+        margin-right: .2rem;
+    }
+
 div.refresh-timer-interval-wrapper {
     width: 100px;
 }

--- a/src/BlazorBoilerplate.Server/Controllers/DbLogController.cs
+++ b/src/BlazorBoilerplate.Server/Controllers/DbLogController.cs
@@ -30,7 +30,7 @@ namespace BlazorBoilerplate.Server.Controllers
             _logger = logger;
         }
 
-        // GET: api/Logs
+        // GET: api/DbLog
         [HttpGet]
         public async Task<ActionResult<ApiResponse>> GetLogs([FromQuery]int pageSize, [FromQuery] int page)
         {
@@ -39,7 +39,22 @@ namespace BlazorBoilerplate.Server.Controllers
                 //placeholder for selector
 
 
-            return await _dbLogManager.Get(pageSize, page, predicate).ConfigureAwait(false);
+            return await _dbLogManager.GetAsync(pageSize, page, predicate).ConfigureAwait(false);
+        }
+
+        [HttpGet("delta")]
+        public async Task<ActionResult<ApiResponse>> GetLogDelta([FromQuery] int deltaIndex)
+        {
+            // TODO: Implement an api-safe client selector // filtering
+            Expression<Func<DbLog, bool>> predicate = _ => true;
+            //placeholder for selector
+
+            return await _dbLogManager.GetDeltaMetaAsync(
+                deltaIndex: deltaIndex,
+                cancellationToken: default
+                ).ConfigureAwait(false);
+
+
         }
 
     }

--- a/src/BlazorBoilerplate.Server/Managers/IDbLogManager.cs
+++ b/src/BlazorBoilerplate.Server/Managers/IDbLogManager.cs
@@ -1,7 +1,5 @@
 ﻿using BlazorBoilerplate.Server.Middleware.Wrappers;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using BlazorBoilerplate.Shared.DataModels;
 using System.Linq.Expressions;
@@ -11,7 +9,9 @@ namespace BlazorBoilerplate.Server.Managers
 {
     public interface IDbLogManager
     {
-        Task Log(DbLog LogItem);
-        Task<ApiResponse> Get(int pageSize, int page, Expression<Func<DbLog, bool>> predicate = null, CancellationToken cancellationToken = default);
+        Task<ApiResponse> GetAsync(int pageSize, int page, Expression<Func<DbLog, bool>> predicate = null, CancellationToken cancellationToken = default);
+
+
+        Task<ApiResponse> GetDeltaMetaAsync(int deltaIndex, Expression<Func<DbLog, bool>> predicate = null, CancellationToken cancellationToken = default);
     }
 }

--- a/src/BlazorBoilerplate.Shared/DataModels/DbLog.cs
+++ b/src/BlazorBoilerplate.Shared/DataModels/DbLog.cs
@@ -17,7 +17,7 @@ namespace BlazorBoilerplate.Shared.DataModels
 
         public string Level { get; set; }
 
-        public DateTime TimeStamp { get; set; }
+        public DateTimeOffset TimeStamp { get; set; }
 
         public string Exception { get; set; }
 

--- a/src/BlazorBoilerplate.Shared/DataModels/PaginationDetails.cs
+++ b/src/BlazorBoilerplate.Shared/DataModels/PaginationDetails.cs
@@ -10,10 +10,32 @@ namespace BlazorBoilerplate.Shared.DataModels
     /// </summary>
     public class PaginationDetails
     {
-        public int PageIndex { get; set; }
+        public int? PageIndex { get; set; }
 
-        public int PageSize { get; set; }
+        public int? PageSize { get; set; }
 
-        public int CollectionSize { get; set; }
+        /// <summary>
+        /// Reference point that captures the relative state of the collection at the time of data generation.
+        /// Usually the index id of the last item present in the collection (returned by client in future requests to enable delta requests)
+        /// </summary>
+        public int? SyncPointReference { get; set; }
+
+
+        /// <summary>
+        /// Total size of the backing collection referenced by the client request.
+        /// </summary>
+        public int? CollectionSize { get; set; }
+
+
+        /// <summary>
+        /// Returns the context of the original request (primarily for troubleshooting purposes but could also help to avoid race conditions)
+        /// </summary>
+        public int? DeltaRequestReference { get; set; } // may need to change to accomodate other reference object types (eg DateTime)
+
+
+        /// <summary>
+        /// Used in Delta Queries to indicate the net change in collection size since the given reference point (SyncPointReference including in the original client request)
+        /// </summary>
+        public int? CollectionSizeDelta { get; set; }
     }
 }

--- a/src/BlazorBoilerplate.Storage/ApplicationDbContext.cs
+++ b/src/BlazorBoilerplate.Storage/ApplicationDbContext.cs
@@ -50,6 +50,13 @@ namespace BlazorBoilerplate.Storage
 
             base.OnModelCreating(modelBuilder);
 
+            modelBuilder.Entity<DbLog>()
+                .HasKey(d => d.Id)
+                .IsClustered(false);
+            modelBuilder.Entity<DbLog>()
+                .HasIndex(d => d.TimeStamp)
+                .IsClustered(true);
+
             modelBuilder.Entity<Message>().ToTable("Messages");
 
             modelBuilder.ApplyConfiguration(new MessageConfiguration());

--- a/src/BlazorBoilerplate.Storage/Migrations/20200329024307_MultiTenantMigration.Designer.cs
+++ b/src/BlazorBoilerplate.Storage/Migrations/20200329024307_MultiTenantMigration.Designer.cs
@@ -4,14 +4,16 @@ using BlazorBoilerplate.Storage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace BlazorBoilerplate.Storage.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200329024307_MultiTenantMigration")]
+    partial class MultiTenantMigration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -169,40 +171,6 @@ namespace BlazorBoilerplate.Storage.Migrations
                         .HasFilter("[NormalizedUserName] IS NOT NULL");
 
                     b.ToTable("AspNetUsers");
-                });
-
-            modelBuilder.Entity("BlazorBoilerplate.Shared.DataModels.DbLog", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
-
-                    b.Property<string>("Exception")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("Level")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("Message")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("MessageTemplate")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("Properties")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<DateTimeOffset>("TimeStamp")
-                        .HasColumnType("datetimeoffset");
-
-                    b.HasKey("Id")
-                        .HasAnnotation("SqlServer:Clustered", false);
-
-                    b.HasIndex("TimeStamp")
-                        .HasAnnotation("SqlServer:Clustered", true);
-
-                    b.ToTable("Logs");
                 });
 
             modelBuilder.Entity("BlazorBoilerplate.Shared.DataModels.Message", b =>

--- a/src/BlazorBoilerplate.Storage/Migrations/20200329024307_MultiTenantMigration.cs
+++ b/src/BlazorBoilerplate.Storage/Migrations/20200329024307_MultiTenantMigration.cs
@@ -3,28 +3,10 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace BlazorBoilerplate.Storage.Migrations
 {
-    public partial class DbLogging : Migration
+    public partial class MultiTenantMigration : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.CreateTable(
-                name: "Logs",
-                columns: table => new
-                {
-                    Id = table.Column<int>(nullable: false)
-                        .Annotation("SqlServer:Identity", "1, 1"),
-                    Message = table.Column<string>(nullable: true),
-                    MessageTemplate = table.Column<string>(nullable: true),
-                    Level = table.Column<string>(nullable: true),
-                    TimeStamp = table.Column<DateTime>(nullable: false),
-                    Exception = table.Column<string>(nullable: true),
-                    Properties = table.Column<string>(nullable: true)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_Logs", x => x.Id);
-                });
-
             migrationBuilder.CreateTable(
                 name: "Tenants",
                 columns: table => new
@@ -54,9 +36,6 @@ namespace BlazorBoilerplate.Storage.Migrations
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropTable(
-                name: "Logs");
-
             migrationBuilder.DropTable(
                 name: "Tenants");
         }

--- a/src/BlazorBoilerplate.Storage/Migrations/20200329024357_SQLDbLoggingMigration.Designer.cs
+++ b/src/BlazorBoilerplate.Storage/Migrations/20200329024357_SQLDbLoggingMigration.Designer.cs
@@ -10,8 +10,8 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BlazorBoilerplate.Storage.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20200326012204_DbLogging")]
-    partial class DbLogging
+    [Migration("20200329024357_SQLDbLoggingMigration")]
+    partial class SQLDbLoggingMigration
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -173,7 +173,7 @@ namespace BlazorBoilerplate.Storage.Migrations
                     b.ToTable("AspNetUsers");
                 });
 
-            modelBuilder.Entity("BlazorBoilerplate.Shared.DataModels.Logs", b =>
+            modelBuilder.Entity("BlazorBoilerplate.Shared.DataModels.DbLog", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -195,10 +195,14 @@ namespace BlazorBoilerplate.Storage.Migrations
                     b.Property<string>("Properties")
                         .HasColumnType("nvarchar(max)");
 
-                    b.Property<DateTime>("TimeStamp")
-                        .HasColumnType("datetime2");
+                    b.Property<DateTimeOffset>("TimeStamp")
+                        .HasColumnType("datetimeoffset");
 
-                    b.HasKey("Id");
+                    b.HasKey("Id")
+                        .HasAnnotation("SqlServer:Clustered", false);
+
+                    b.HasIndex("TimeStamp")
+                        .HasAnnotation("SqlServer:Clustered", true);
 
                     b.ToTable("Logs");
                 });

--- a/src/BlazorBoilerplate.Storage/Migrations/20200329024357_SQLDbLoggingMigration.cs
+++ b/src/BlazorBoilerplate.Storage/Migrations/20200329024357_SQLDbLoggingMigration.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace BlazorBoilerplate.Storage.Migrations
+{
+    public partial class SQLDbLoggingMigration : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Logs",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Message = table.Column<string>(nullable: true),
+                    MessageTemplate = table.Column<string>(nullable: true),
+                    Level = table.Column<string>(nullable: true),
+                    TimeStamp = table.Column<DateTimeOffset>(nullable: false),
+                    Exception = table.Column<string>(nullable: true),
+                    Properties = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Logs", x => x.Id)
+                        .Annotation("SqlServer:Clustered", false);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Logs_TimeStamp",
+                table: "Logs",
+                column: "TimeStamp")
+                .Annotation("SqlServer:Clustered", true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Logs");
+        }
+    }
+}


### PR DESCRIPTION
Added Delta Query Support for DbLog Api/Viewing page.
Separated Dblog migration from Multitenant Migration (Whoops my bad)
Tried some optimization for DbLog Table and log queries in general.  It's not going to get anywhere near the performance of real logging applications like graylog but it's better than nothing?  

Breaking Change: This will require deleting and remaking any existing databases due to redoing / separating  the db logging migration

