### PR TITLE
ReturnUrl patch

### DIFF
--- a/src/Server/BlazorBoilerplate.Server/Pages/Login.cshtml.cs
+++ b/src/Server/BlazorBoilerplate.Server/Pages/Login.cshtml.cs
@@ -35,7 +35,7 @@ namespace BlazorBoilerplate.Server.Pages
                     result = true;
 
                     if (string.IsNullOrEmpty(loginParameters.ReturnUrl) || loginParameters.ReturnUrl == "/")
-                        loginParameters.ReturnUrl = (await _context.UserProfiles.SingleOrDefaultAsync(i => i.ApplicationUser.NormalizedUserName == loginParameters.UserName.ToUpper()))?.LastPageVisited ?? string.Empty;
+                        loginParameters.ReturnUrl = (await _context.UserProfiles.SingleOrDefaultAsync(i => i.ApplicationUser.NormalizedUserName == loginParameters.UserName.ToUpper()))?.LastPageVisited ?? "/";
 
                     if ((response.Result as LoginResponseModel)?.RequiresTwoFactor == true)
                         loginParameters.ReturnUrl = $"{Shared.Settings.LoginWith2faPath}?returnurl={Uri.EscapeDataString(loginParameters.ReturnUrl)}";

--- a/src/Shared/Modules/BlazorBoilerplate.Theme.Material/Shared/Components/Breadcrumbs.razor
+++ b/src/Shared/Modules/BlazorBoilerplate.Theme.Material/Shared/Components/Breadcrumbs.razor
@@ -73,7 +73,7 @@
 
     private async Task BuildBreadcrumbsAsync()
     {
-        string uri = navigationManager.Uri.Split('?')[0].Replace(baseUrl, string.Empty).Trim();
+        string uri = navigationManager.Uri.Split('?')[0].Replace(baseUrl, "/").Trim();
 
         if (IsLoggedIn)
         {


### PR DESCRIPTION
using `string.Empty` as empty `ReturnUrl ` caused 'value can not be empty' error in `localRedirect` of login page. Replacing with `"/"` fixes the problem.