### PR TITLE
Update the ChartJs.Blazor link again

### DIFF
--- a/src/Shared/Modules/BlazorBoilerplate.Theme.Material.Demo/Pages/Dashboard.razor
+++ b/src/Shared/Modules/BlazorBoilerplate.Theme.Material.Demo/Pages/Dashboard.razor
@@ -6,7 +6,7 @@
 
 <p>
     Expecting to see a bunch of flashy charts then you download the repo and delete them all because you don't need them? <br />
-    Check out <a href="https://github.com/Joelius300/ChartJSBlazor" target="_blank">https://github.com/Joelius300/ChartJSBlazor</a> and you will find a great resource for animated charts for a dashboard.<br />
+    Check out <a href="https://github.com/mariusmuntean/ChartJs.Blazor" target="_blank">ChartJs.Blazor</a> and you will find a great resource for animated charts for a dashboard.<br />
 </p>
 <hr />
 <h2>Counter</h2>


### PR DESCRIPTION
First of all, sorry for not opening an issue. I thought this change is small enough to just submit the PR directly.

The old repo ([Joelius300/ChartJSBlazor](https://github.com/Joelius300/ChartJSBlazor)) was archived a while ago and all the new development takes place back on the original repo [mariusmuntean/ChartJs.Blazor](https://github.com/mariusmuntean/ChartJs.Blazor).

You should check out the new [2.0 release](https://github.com/mariusmuntean/ChartJs.Blazor/releases/tag/v2.0.0) if you're interested.

Basically reverts https://github.com/enkodellc/blazorboilerplate/pull/12 but I also removed the IMO unnecessary part of the link text (the `https://github.com`).

Also, @enkodellc are you still interested in adding a sample chart to your project? You mentioned that in the linked PR.