### PR TITLE
only use StoreName.My in Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Complete all Blazor dependencies.
 
 ## Publish on IIS - What works for me on my Windows Server 2016 & SQL Server 2014 (Enkodellc)
 1. Publish BlazorBoilerplate.Server project to your IIS website folder.
-2. Install your SSL. Make sure your SSL is in the **My** Certificate Store.
+2. Install your SSL. Make sure your SSL is in the **WebHosting** Certificate Store, and in Linux **My** Certificate Store.
     - A free certificate from [Let's Encrypt](https://letsencrypt.org/) will work. 
     - For steps 2 & 3 the utility [win-acme](https://github.com/win-acme/win-acme) installs the
 certificate on your server, performs renewal and configure your IIS Website Bindings to have https binding with the SSL certificate set and Port 443 for default.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Complete all Blazor dependencies.
 
 ## Publish on IIS - What works for me on my Windows Server 2016 & SQL Server 2014 (Enkodellc)
 1. Publish BlazorBoilerplate.Server project to your IIS website folder.
-2. Install your SSL. Make sure your SSL is in the **WebHosting** Certificate Store.
+2. Install your SSL. Make sure your SSL is in the **My** Certificate Store.
     - A free certificate from [Let's Encrypt](https://letsencrypt.org/) will work. 
     - For steps 2 & 3 the utility [win-acme](https://github.com/win-acme/win-acme) installs the
 certificate on your server, performs renewal and configure your IIS Website Bindings to have https binding with the SSL certificate set and Port 443 for default.

--- a/src/Server/BlazorBoilerplate.Server/BlazorBoilerplate.Server.csproj
+++ b/src/Server/BlazorBoilerplate.Server/BlazorBoilerplate.Server.csproj
@@ -7,6 +7,7 @@
     <DockerfileFile>$(SolutionDir)/Utils/Docker/Dockerfile</DockerfileFile>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerComposeProjectPath>$(SolutionDir)/Utils/Docker/docker-compose.dcproj</DockerComposeProjectPath>
+    <UserSecretsId>dccf98cd-91ea-4e92-b852-ad056fc2b6bf</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Server/BlazorBoilerplate.Server/Startup.cs
+++ b/src/Server/BlazorBoilerplate.Server/Startup.cs
@@ -174,11 +174,13 @@ namespace BlazorBoilerplate.Server
                 {
                     var certificateThumbprint = Configuration[$"{projectName}:CertificateThumbprint"];
                     var storeLocation = StoreLocation.LocalMachine;
+                    dynamic storeName = "WebHosting";
                     if (OperatingSystem.IsLinux())
                     {
                         storeLocation = StoreLocation.CurrentUser;
+                        storeName = StoreName.My;
                     }
-                    using (X509Store store = new X509Store(StoreName.My, storeLocation))
+                    using (X509Store store = new X509Store(storeName, storeLocation))
                     {
                         store.Open(OpenFlags.ReadOnly);
                         var certs = store.Certificates.Find(X509FindType.FindByThumbprint, certificateThumbprint, false);


### PR DESCRIPTION
Need to update doc to correlate with code change. We need to conform to the standards of what .net supports. See https://docs.microsoft.com/en-us/dotnet/standard/security/cross-platform-cryptography and lookup CurrentUser\My vs LocalMachine\My. Nowhere is there "WebHosting".

We should also allow user secrets. See https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-5.0
