### PR TITLE
fix docker config; add dev env flexability;

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,14 @@ This project is licensed under the terms of the [MIT license](LICENSE).
 - Prerequisite: Install [Docker Desktop](https://go.microsoft.com/fwlink/?linkid=847268) 
 - Include / Reload **docker-compose** project in solution.
 - [Do Docker stuff](https://docs.docker.com/v17.09/docker-for-windows/install/) - I don't have much experience with Docker.
+- The following will happen in the **browser** with ASPNETCORE_ENVIRONMENT=Development:
+- Connecting via localhost in chrome or firefox will work until you attempt to login. Clicking login you will get a console error: "Cannot assign requested address (localhost:port)" because the js client is trying to connect to your local machine rather than the docker container.
+- Connecting over external ip address: Will work, but you will get a console error in the following scenarios:
+- in chrome over http: Cannot read property 'register' of undefined
+- in chrome over https: DOMException: Failed to register a ServiceWorker for scope ('https://x.x.x.x:port/') with script ('https://x.x.x.x:port/service-worker.js'): An SSL certificate error occurred when fetching the script. 
+- in firefox over http: navigator.serviceWorker is undefined
+- in firefox over https: No error until after you login. After login you will get error: WebSocket is not in the OPEN state. The setting ServerCertificateCustomValidationCallback = () => { return true; }   prevents the ssl error.
+- In ASPNETCORE_ENVIRONMENT=Production: Same as above except http will redirect to https
 
 ### Azure Support
 - [Azure Hosting Wiki](https://github.com/enkodellc/blazorboilerplate/wiki/Hosting-Blazor-boilerplate-on-Microsoft-Azure) 

--- a/src/Server/BlazorBoilerplate.Server/Startup.cs
+++ b/src/Server/BlazorBoilerplate.Server/Startup.cs
@@ -542,7 +542,13 @@ namespace BlazorBoilerplate.Server
                 var navigationManager = s.GetRequiredService<NavigationManager>();
                 var httpContextAccessor = s.GetRequiredService<IHttpContextAccessor>();
                 var cookies = httpContextAccessor.HttpContext.Request.Cookies;
-                var client = new HttpClient(new HttpClientHandler { UseCookies = false });
+                var httpClientHandler = new HttpClientHandler(){ UseCookies = false };
+                if (_environment.IsDevelopment())
+                {
+                    // Return 'true' to allow certificates that are untrusted/invalid
+                    httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => { return true; };
+                }
+                var client = new HttpClient(httpClientHandler);
                 if (cookies.Any())
                 {
                     var cks = new List<string>();
@@ -601,11 +607,11 @@ namespace BlazorBoilerplate.Server
             }
             else
             {
+                app.UseHttpsRedirection();
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 //    app.UseHsts(); //HSTS Middleware (UseHsts) to send HTTP Strict Transport Security Protocol (HSTS) headers to clients.
             }
 
-            app.UseHttpsRedirection();
             app.UseStaticFiles();
             app.UseBlazorFrameworkFiles(); //ClientSideBlazor
 

--- a/src/Utils/Docker/Dockerfile
+++ b/src/Utils/Docker/Dockerfile
@@ -1,21 +1,22 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim AS base
-WORKDIR /app
+FROM mcr.microsoft.com/dotnet/aspnet:5.0-buster-slim AS base
+WORKDIR /
+EXPOSE 443
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
-WORKDIR /src
-COPY ["/BlazorBoilerplate.Server/BlazorBoilerplate.Server.csproj", "BlazorBoilerplate.Server/"]
-COPY ["/BlazorBoilerplate.Shared/BlazorBoilerplate.Shared.csproj", "BlazorBoilerplate.Shared/"]
-COPY ["/BlazorBoilerplate.Client/BlazorBoilerplate.Client.csproj", "BlazorBoilerplate.Client/"]
-RUN dotnet restore "BlazorBoilerplate.Server/BlazorBoilerplate.Server.csproj"
+FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim AS build
+WORKDIR /
 COPY . .
-WORKDIR "/src/BlazorBoilerplate.Server"
+RUN dotnet restore "src/Server/BlazorBoilerplate.Server/BlazorBoilerplate.Server.csproj"
+WORKDIR "/src/Server/BlazorBoilerplate.Server"
 RUN dotnet build "BlazorBoilerplate.Server.csproj" -c Release -o /app/build --no-restore
 
 FROM build AS publish
 RUN dotnet publish "BlazorBoilerplate.Server.csproj" -c Release -o /app/publish
+RUN dotnet dev-certs https --clean
+RUN dotnet dev-certs https -ep /app/publish/aspnetapp.pfx -p Admin123
 
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
+COPY --from=publish /app/publish/aspnetapp.pfx ./AuthSample.pfx
 ENTRYPOINT ["dotnet", "BlazorBoilerplate.Server.dll"]

--- a/src/Utils/Docker/docker-compose.yml
+++ b/src/Utils/Docker/docker-compose.yml
@@ -3,10 +3,11 @@ version: '3.5'
 services:
   blazorboilerplate:
     build:
-      context: ./
-      dockerfile: ./Dockerfile
+      context: ../../../
+      dockerfile: ./src/Utils/Docker/Dockerfile
     ports:
       - 53415:80
+      - 53443:443
     depends_on:
       - sqlserver
     environment:
@@ -16,6 +17,9 @@ services:
       - BlazorBoilerplate__UseSqlServer=true
       - BlazorBoilerplate__ApplicationUrl=blazorboilerplate
       - BlazorBoilerplate__IS4ApplicationUrl=blazorboilerplate
+      - ASPNETCORE_URLS=https://+:443;http://+80
+      - ASPNETCORE_Kestrel__Certificates__Default__Password=Admin123
+      - ASPNETCORE_Kestrel__Certificates__Default__Path=aspnetapp.pfx
     networks:
       - bb
     restart: on-failure


### PR DESCRIPTION
Assuming the docker config is broken, I am attempting to get it fixed. Also, I wanted to document the connection scenarios depending on how one connects when using a self signed cert. The error is expected, but stressful if it's not a known error. Allowing some flexibility in the dev environment around self signed certificates seems ok to me. Everyone should know not to run in Development environment in Production.