### PR TITLE
combine BaseAddress with chathub

### DIFF
--- a/src/Shared/Modules/BlazorBoilerplate.Theme.Material.Demo/Hubs/ChatClient.cs
+++ b/src/Shared/Modules/BlazorBoilerplate.Theme.Material.Demo/Hubs/ChatClient.cs
@@ -26,7 +26,7 @@ namespace BlazorBoilerplate.Theme.Material.Demo.Hubs
         public ChatClient(HttpClient httpClient)
         {
             connection = new HubConnectionBuilder()
-                .WithUrl($"{httpClient.BaseAddress}chathub", options =>
+                .WithUrl(new Uri(httpClient.BaseAddress, "chathub"), options =>
                 {
                     foreach (var header in httpClient.DefaultRequestHeaders)
                         if (header.Key == "Cookie")


### PR DESCRIPTION
Using the equivalent of Path.Combine to combine a base url with its fragment. new Uri(base,fragment)