### PR TITLE
require MultipleActiveResultSets=true

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Complete all Blazor dependencies.
     - For steps 2 & 3 the utility [win-acme](https://github.com/win-acme/win-acme) installs the
 certificate on your server, performs renewal and configure your IIS Website Bindings to have https binding with the SSL certificate set and Port 443 for default.
 
-4. Configure your IIS Website Bindings to have https binding with the SSL certificate set and Port 443 for default.
-3. Configure / create appsettings.production.config. Set  Connection String, Thumbprint / SSL. Thumbprint example:  **143fbd7bc36e78b1bcf9a53c13336eaebe33353a**
-4. Login with either the user **[user | user123]** or admin **[admin | admin123]** default accounts.
+3. Configure your IIS Website Bindings to have https binding with the SSL certificate set and Port 443 for default.
+4. Configure / create appsettings.production.config. Set Connection String. If you are using Sql Server then make sure your connection string contains **MultipleActiveResultSets=true**, Set Thumbprint / SSL. Thumbprint example:  **143fbd7bc36e78b1bcf9a53c13336eaebe33353a**
+5. Login with either the user **[user | user123]** or admin **[admin | admin123]** default accounts.
 
 ### Thanks To
 - [Blazor](https://blazor.net)

--- a/src/Server/BlazorBoilerplate.Storage/ServiceCollectionExtensions.cs
+++ b/src/Server/BlazorBoilerplate.Storage/ServiceCollectionExtensions.cs
@@ -45,11 +45,19 @@ namespace BlazorBoilerplate.Storage
             var useSqlServer = !Convert.ToBoolean(configuration[$"{projectName}:UsePostgresServer"] ?? "false");
 
             if (useSqlServer)
+            {
+                var connectionString = configuration.GetConnectionString("DefaultConnection");
+                if(string.IsNullOrEmpty(connectionString))
+                    throw new ArgumentNullException("The DefaultConnection was not found.");
+                if(connectionString.ToLower().Contains("multipleactiveresultsets=true") == false)
+                    throw new ArgumentException("When Sql Server is in use the DefaultConnection must contain: MultipleActiveResultSets=true");
                 builder.UseSqlServer(configuration.GetConnectionString("DefaultConnection"), options =>
                 {
                     options.CommandTimeout(60);
                     options.MigrationsAssembly(migrationsAssembly);
                 });
+
+            }
             else
                 builder.UseNpgsql(configuration.GetConnectionString("PostgresConnection"), options => options.MigrationsAssembly(migrationsAssembly));
         }


### PR DESCRIPTION
Per @GioviQ
When MultipleActiveResultSets=false, will lead to error: 
An exception occurred while iterating over the results of a query for context type 'BlazorBoilerplate.Storage.LocalizationDbContext'.
System.InvalidOperationException: There is already an open DataReader associated with this Connection which must be closed first.