### PR TITLE
Add css isolation for Razor class library (RCL) BlazorBoilerplate.Theme.Material Module

### DIFF
--- a/src/Server/BlazorBoilerplate.Server/Pages/_Index.cshtml
+++ b/src/Server/BlazorBoilerplate.Server/Pages/_Index.cshtml
@@ -31,6 +31,7 @@
     }
     <base href="~/" />
     <link href="manifest.json" rel="manifest" />
+    <link href="_content/BlazorBoilerplate.Theme.Material/BlazorBoilerplate.Theme.Material.bundle.scp.css" rel="stylesheet">
 </head>
 <body>
     @{

--- a/src/Shared/Modules/BlazorBoilerplate.Theme.Material/Shared/Layouts/MainLayout.razor.css
+++ b/src/Shared/Modules/BlazorBoilerplate.Theme.Material/Shared/Layouts/MainLayout.razor.css
@@ -1,0 +1,3 @@
+﻿.hidden-mdc-down {
+    white-space:nowrap;
+}

--- a/src/Shared/Modules/BlazorBoilerplate.Theme.Material/wwwroot/css/site.css
+++ b/src/Shared/Modules/BlazorBoilerplate.Theme.Material/wwwroot/css/site.css
@@ -179,9 +179,6 @@ app {
     z-index: -1;
     transition: all 0.3s ease-in-out 0s, visibility 0s linear 0.3s, z-index 0s linear 0.01s;
 }
-.hidden-mdc-down {
-    white-space:nowrap;
-}
 .hidden-mdc-down nav a {
     color: #E00;
     display: block;

--- a/src/Shared/Modules/BlazorBoilerplate.Theme.Material/wwwroot/css/site.css
+++ b/src/Shared/Modules/BlazorBoilerplate.Theme.Material/wwwroot/css/site.css
@@ -179,7 +179,9 @@ app {
     z-index: -1;
     transition: all 0.3s ease-in-out 0s, visibility 0s linear 0.3s, z-index 0s linear 0.01s;
 }
-
+.hidden-mdc-down {
+    white-space:nowrap;
+}
 .hidden-mdc-down nav a {
     color: #E00;
     display: block;


### PR DESCRIPTION
Left Nav Bar wraps in mobile view. Try it out in the f12 dev tools, switch to mobile view. This doesn't fix the overlap, but at least it doesn't wrap (looks less buggy)

