### PR TITLE
prevent docker logging from filling hd

### DIFF
--- a/src/Utils/Terraform/AWS/bash.tmpl
+++ b/src/Utils/Terraform/AWS/bash.tmpl
@@ -13,6 +13,7 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o 
 echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt-get update -y
 sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose -y
+echo "{'log-driver': 'json-file','log-opts': {'max-size': '20m', 'max-file': '3'}}" > /etc/docker/daemon.json
 sudo systemctl enable docker
 sudo systemctl start docker
 echo "${docker_compose}" > /opt/docker-compose.yml


### PR DESCRIPTION
I noticed the hd fills up after some time, but this pull request should prevent it