### PR TITLE
add environment variables

### DIFF
--- a/src/Server/BlazorBoilerplate.Server/Program.cs
+++ b/src/Server/BlazorBoilerplate.Server/Program.cs
@@ -21,6 +21,7 @@ namespace BlazorBoilerplate.Server
             var configuration = new ConfigurationBuilder()
                 .AddJsonFile("appsettings.json")
                 .AddJsonFile($"appsettings.{environment}.json", optional: true)
+                .AddEnvironmentVariables()
                 .Build();
 
             Log.Logger = new LoggerConfiguration()

--- a/src/Server/BlazorBoilerplate.Server/appsettings.json
+++ b/src/Server/BlazorBoilerplate.Server/appsettings.json
@@ -119,6 +119,7 @@
           "retainedFileCountLimit": 5
         }
       }
+      //,{"Name": "Console"} //Helpful when Debugging
     ]
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
Environment variables are not longer being pulled in by default in linux. 