### PR TITLE
Handle missing Layout for TopSection

### DIFF
--- a/src/Shared/BlazorBoilerplate.UI.Base/Shared/Components/TopSection.cs
+++ b/src/Shared/BlazorBoilerplate.UI.Base/Shared/Components/TopSection.cs
@@ -1,4 +1,4 @@
-﻿using BlazorBoilerplate.UI.Base.Shared.Layouts;
+using BlazorBoilerplate.UI.Base.Shared.Layouts;
 using Microsoft.AspNetCore.Components;
 using System;
 
@@ -14,14 +14,16 @@ namespace BlazorBoilerplate.UI.Base.Shared.Components
 
         protected override void OnInitialized()
         {
-            RootLayout.SetTopSection(this);
+            if (RootLayout != null) 
+                RootLayout.SetTopSection(this);
+
             base.OnInitialized();
         }
 
         protected override bool ShouldRender()
         {
             var shouldRender = base.ShouldRender();
-            if (shouldRender)
+            if (shouldRender && RootLayout != null)
             {
                 RootLayout.Update();
             }

--- a/src/Shared/BlazorBoilerplate.UI.Base/Shared/Components/TopSection.cs
+++ b/src/Shared/BlazorBoilerplate.UI.Base/Shared/Components/TopSection.cs
@@ -13,9 +13,8 @@ namespace BlazorBoilerplate.UI.Base.Shared.Components
         public RenderFragment ChildContent { get; set; }
 
         protected override void OnInitialized()
-        {
-            if (RootLayout != null) 
-                RootLayout.SetTopSection(this);
+        { 
+            RootLayout?.SetTopSection(this);
 
             base.OnInitialized();
         }
@@ -23,10 +22,10 @@ namespace BlazorBoilerplate.UI.Base.Shared.Components
         protected override bool ShouldRender()
         {
             var shouldRender = base.ShouldRender();
-            if (shouldRender && RootLayout != null)
-            {
-                RootLayout.Update();
-            }
+            
+            if (shouldRender)
+                RootLayout?.Update();
+            
             return base.ShouldRender();
         }
 


### PR DESCRIPTION
If the razor page does not have a layout and has a top section it will error. This at least prevents the error. Possible better solution is to show an error.  @GioviQ  any suggestions.