### PR TITLE
Fix: Person ids not being generated on creation

### DIFF
--- a/src/Server/BlazorBoilerplate.Server/Managers/AccountManager.cs
+++ b/src/Server/BlazorBoilerplate.Server/Managers/AccountManager.cs
@@ -785,7 +785,7 @@ namespace BlazorBoilerplate.Server.Managers
 
             if (user.Person == null &&
                 (!string.IsNullOrWhiteSpace(userViewModel.FirstName) || !string.IsNullOrWhiteSpace(userViewModel.LastName) || !string.IsNullOrWhiteSpace(userViewModel.CompanyName)))
-                user.Person = new Person();
+                user.Person = new Person() {Id = Guid.NewGuid() };
 
             user.Person.FirstName = userViewModel.FirstName;
             user.Person.LastName = userViewModel.LastName;
@@ -962,7 +962,7 @@ namespace BlazorBoilerplate.Server.Managers
                 user.UserName = userViewModel.UserName;
 
             if (user.Person == null)
-                user.Person = new Person();
+                user.Person = new Person() { Id = Guid.NewGuid() };
 
             user.Person.FirstName = userViewModel.FirstName;
             user.Person.LastName = userViewModel.LastName;


### PR DESCRIPTION
Person objects were previously only created correctly in ExternalAuthManager.ExternalSignIn but now they are also correctly created correctly in AccountManager.UpdateUser and AccountManager.AdminUpdateUser.